### PR TITLE
fix selection bug

### DIFF
--- a/matisse/src/main/java/com/zhihu/matisse/internal/model/SelectedItemCollection.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/model/SelectedItemCollection.java
@@ -34,7 +34,7 @@ import java.util.Set;
 @SuppressWarnings("unused")
 public class SelectedItemCollection {
 
-    private static final String STATE_SELECTION = "state_selection";
+    public static final String STATE_SELECTION = "state_selection", STATE_COLLECTION_TYPE = "state_collection_type";
     private final Context mContext;
     private Set<Item> mItems;
     private SelectionSpec mSpec;
@@ -64,12 +64,13 @@ public class SelectedItemCollection {
         mContext = context;
     }
 
-    public void onCreate(Bundle savedInstanceState, SelectionSpec spec) {
-        if (savedInstanceState == null) {
+    public void onCreate(Bundle bundle, SelectionSpec spec) {
+        if (bundle == null) {
             mItems = new LinkedHashSet<>();
         } else {
-            List<Item> saved = savedInstanceState.getParcelableArrayList(STATE_SELECTION);
+            List<Item> saved = bundle.getParcelableArrayList(STATE_SELECTION);
             mItems = new LinkedHashSet<>(saved);
+            mCollectionType = bundle.getInt(STATE_COLLECTION_TYPE, COLLECTION_UNDEFINED);
         }
         mSpec = spec;
     }
@@ -80,6 +81,14 @@ public class SelectedItemCollection {
 
     public void onSaveInstanceState(Bundle outState) {
         outState.putParcelableArrayList(STATE_SELECTION, new ArrayList<>(mItems));
+        outState.putInt(STATE_COLLECTION_TYPE, mCollectionType);
+    }
+
+    public Bundle getDataWithBundle() {
+        Bundle bundle = new Bundle();
+        bundle.putParcelableArrayList(STATE_SELECTION, new ArrayList<>(mItems));
+        bundle.putInt(STATE_COLLECTION_TYPE, mCollectionType);
+        return bundle;
     }
 
     public boolean add(Item item) {
@@ -104,13 +113,16 @@ public class SelectedItemCollection {
         return result;
     }
 
-    public void overwrite(ArrayList<Item> items) {
+    public void overwrite(ArrayList<Item> items, int collectionType) {
         if (items.size() == 0) {
             mCollectionType = COLLECTION_UNDEFINED;
+        } else {
+            mCollectionType = collectionType;
         }
         mItems.clear();
         mItems.addAll(items);
     }
+
 
     public List<Item> asList() {
         return new ArrayList<>(mItems);

--- a/matisse/src/main/java/com/zhihu/matisse/internal/ui/BasePreviewActivity.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/ui/BasePreviewActivity.java
@@ -27,22 +27,19 @@ import android.view.WindowManager;
 import android.widget.TextView;
 
 import com.zhihu.matisse.R;
+import com.zhihu.matisse.internal.entity.IncapableCause;
 import com.zhihu.matisse.internal.entity.Item;
 import com.zhihu.matisse.internal.entity.SelectionSpec;
-import com.zhihu.matisse.internal.entity.IncapableCause;
 import com.zhihu.matisse.internal.model.SelectedItemCollection;
 import com.zhihu.matisse.internal.ui.adapter.PreviewPagerAdapter;
 import com.zhihu.matisse.internal.ui.widget.CheckView;
 import com.zhihu.matisse.internal.utils.PhotoMetadataUtils;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public abstract class BasePreviewActivity extends AppCompatActivity implements View.OnClickListener,
         ViewPager.OnPageChangeListener {
 
-    public static final String EXTRA_DEFAULT_SELECTED = "extra_default_selected";
-    public static final String EXTRA_RESULT_SELECTED = "extra_result_selected";
+    public static final String EXTRA_DEFAULT_BUNDLE = "extra_default_bundle";
+    public static final String EXTRA_RESULT_BUNDLE = "extra_result_bundle";
     public static final String EXTRA_RESULT_APPLY = "extra_result_apply";
 
     protected final SelectedItemCollection mSelectedCollection = new SelectedItemCollection(this);
@@ -70,10 +67,11 @@ public abstract class BasePreviewActivity extends AppCompatActivity implements V
         if (mSpec.needOrientationRestriction()) {
             setRequestedOrientation(mSpec.orientation);
         }
-        mSelectedCollection.onCreate(savedInstanceState, mSpec);
+
         if (savedInstanceState == null) {
-            mSelectedCollection.setDefaultSelection(
-                    getIntent().<Item>getParcelableArrayListExtra(EXTRA_DEFAULT_SELECTED));
+            mSelectedCollection.onCreate(getIntent().getBundleExtra(EXTRA_DEFAULT_BUNDLE), mSpec);
+        } else {
+            mSelectedCollection.onCreate(savedInstanceState, mSpec);
         }
 
         mButtonBack = (TextView) findViewById(R.id.button_back);
@@ -199,8 +197,7 @@ public abstract class BasePreviewActivity extends AppCompatActivity implements V
 
     protected void sendBackResult(boolean apply) {
         Intent intent = new Intent();
-        List<Item> checked = mSelectedCollection.asList();
-        intent.putParcelableArrayListExtra(EXTRA_RESULT_SELECTED, (ArrayList<Item>) checked);
+        intent.putExtra(EXTRA_RESULT_BUNDLE, mSelectedCollection.getDataWithBundle());
         intent.putExtra(EXTRA_RESULT_APPLY, apply);
         setResult(Activity.RESULT_OK, intent);
     }

--- a/matisse/src/main/java/com/zhihu/matisse/internal/ui/SelectedPreviewActivity.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/ui/SelectedPreviewActivity.java
@@ -19,6 +19,7 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 
 import com.zhihu.matisse.internal.entity.Item;
+import com.zhihu.matisse.internal.model.SelectedItemCollection;
 
 import java.util.List;
 
@@ -28,7 +29,8 @@ public class SelectedPreviewActivity extends BasePreviewActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        List<Item> selected = getIntent().getParcelableArrayListExtra(EXTRA_DEFAULT_SELECTED);
+        Bundle bundle = getIntent().getBundleExtra(EXTRA_DEFAULT_BUNDLE);
+        List<Item> selected = bundle.getParcelableArrayList(SelectedItemCollection.STATE_SELECTION);
         mAdapter.addAll(selected);
         mAdapter.notifyDataSetChanged();
         if (mSpec.countable) {

--- a/matisse/src/main/java/com/zhihu/matisse/ui/MatisseActivity.java
+++ b/matisse/src/main/java/com/zhihu/matisse/ui/MatisseActivity.java
@@ -152,18 +152,22 @@ public class MatisseActivity extends AppCompatActivity implements
             return;
 
         if (requestCode == REQUEST_CODE_PREVIEW) {
-            ArrayList<Item> selected = data.getParcelableArrayListExtra(BasePreviewActivity.EXTRA_RESULT_SELECTED);
+            Bundle resultBundle = data.getBundleExtra(BasePreviewActivity.EXTRA_RESULT_BUNDLE);
+            ArrayList<Item> selected = resultBundle.getParcelableArrayList(SelectedItemCollection.STATE_SELECTION);
+            int collectionType = resultBundle.getInt(SelectedItemCollection.STATE_COLLECTION_TYPE, SelectedItemCollection.COLLECTION_UNDEFINED);
             if (data.getBooleanExtra(BasePreviewActivity.EXTRA_RESULT_APPLY, false)) {
                 Intent result = new Intent();
                 ArrayList<Uri> selectedUris = new ArrayList<>();
-                for (Item item : selected) {
-                    selectedUris.add(item.getContentUri());
+                if (selected != null) {
+                    for (Item item : selected) {
+                        selectedUris.add(item.getContentUri());
+                    }
                 }
                 result.putParcelableArrayListExtra(EXTRA_RESULT_SELECTION, selectedUris);
                 setResult(RESULT_OK, result);
                 finish();
             } else {
-                mSelectedCollection.overwrite(selected);
+                mSelectedCollection.overwrite(selected, collectionType);
                 Fragment mediaSelectionFragment = getSupportFragmentManager().findFragmentByTag(
                         MediaSelectionFragment.class.getSimpleName());
                 if (mediaSelectionFragment instanceof MediaSelectionFragment) {
@@ -200,7 +204,7 @@ public class MatisseActivity extends AppCompatActivity implements
     public void onClick(View v) {
         if (v.getId() == R.id.button_preview) {
             Intent intent = new Intent(this, SelectedPreviewActivity.class);
-            intent.putExtra(BasePreviewActivity.EXTRA_DEFAULT_SELECTED, (ArrayList<Item>) mSelectedCollection.asList());
+            intent.putExtra(BasePreviewActivity.EXTRA_DEFAULT_BUNDLE, mSelectedCollection.getDataWithBundle());
             startActivityForResult(intent, REQUEST_CODE_PREVIEW);
         } else if (v.getId() == R.id.button_apply) {
             Intent result = new Intent();
@@ -279,7 +283,7 @@ public class MatisseActivity extends AppCompatActivity implements
         Intent intent = new Intent(this, AlbumPreviewActivity.class);
         intent.putExtra(AlbumPreviewActivity.EXTRA_ALBUM, album);
         intent.putExtra(AlbumPreviewActivity.EXTRA_ITEM, item);
-        intent.putExtra(BasePreviewActivity.EXTRA_DEFAULT_SELECTED, (ArrayList<Item>) mSelectedCollection.asList());
+        intent.putExtra(BasePreviewActivity.EXTRA_DEFAULT_BUNDLE, mSelectedCollection.getDataWithBundle());
         startActivityForResult(intent, REQUEST_CODE_PREVIEW);
     }
 


### PR DESCRIPTION
Now Matisse does not support select images and videos at the same time, but when you select some images and then jump to preview page, you can select video. Or you select some images in preview page and click back button, you can select video in selection page. This pr will fix this bug. 