### PR TITLE
A bunch of fixes

### DIFF
--- a/matisse/src/main/java/com/zhihu/matisse/internal/model/AlbumCollection.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/model/AlbumCollection.java
@@ -19,84 +19,34 @@ package com.zhihu.matisse.internal.model;
 import android.content.Context;
 import android.database.Cursor;
 import android.os.Bundle;
-import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.LoaderManager;
 import android.support.v4.content.Loader;
 
 import com.zhihu.matisse.internal.loader.AlbumLoader;
 
-import java.lang.ref.WeakReference;
-
 public class AlbumCollection implements LoaderManager.LoaderCallbacks<Cursor> {
-    private static final int LOADER_ID = 1;
-    private static final String STATE_CURRENT_SELECTION = "state_current_selection";
-    private WeakReference<Context> mContext;
-    private LoaderManager mLoaderManager;
+
+    private Context mContext;
     private AlbumCallbacks mCallbacks;
-    private int mCurrentSelection;
+
+    public AlbumCollection(Context context, AlbumCallbacks callbacks) {
+        mContext = context;
+        mCallbacks = callbacks;
+    }
 
     @Override
     public Loader<Cursor> onCreateLoader(int id, Bundle args) {
-        Context context = mContext.get();
-        if (context == null) {
-            return null;
-        }
-        return new AlbumLoader(context);
+        return new AlbumLoader(mContext);
     }
 
     @Override
     public void onLoadFinished(Loader<Cursor> loader, Cursor data) {
-        Context context = mContext.get();
-        if (context == null) {
-            return;
-        }
-
         mCallbacks.onAlbumLoad(data);
     }
 
     @Override
     public void onLoaderReset(Loader<Cursor> loader) {
-        Context context = mContext.get();
-        if (context == null) {
-            return;
-        }
-
         mCallbacks.onAlbumReset();
-    }
-
-    public void onCreate(FragmentActivity activity, AlbumCallbacks callbacks) {
-        mContext = new WeakReference<Context>(activity);
-        mLoaderManager = activity.getSupportLoaderManager();
-        mCallbacks = callbacks;
-    }
-
-    public void onRestoreInstanceState(Bundle savedInstanceState) {
-        if (savedInstanceState == null) {
-            return;
-        }
-
-        mCurrentSelection = savedInstanceState.getInt(STATE_CURRENT_SELECTION);
-    }
-
-    public void onSaveInstanceState(Bundle outState) {
-        outState.putInt(STATE_CURRENT_SELECTION, mCurrentSelection);
-    }
-
-    public void onDestroy() {
-        mLoaderManager.destroyLoader(LOADER_ID);
-        mCallbacks = null;
-    }
-
-    public void loadAlbums() {
-        mLoaderManager.initLoader(LOADER_ID, null, this);
-    }
-
-    public int getCurrentSelection() {
-        return mCurrentSelection;
-    }
-
-    public void setStateCurrentSelection(int currentSelection) {
-        mCurrentSelection = currentSelection;
     }
 
     public interface AlbumCallbacks {

--- a/matisse/src/main/res/layout/activity_matisse.xml
+++ b/matisse/src/main/res/layout/activity_matisse.xml
@@ -33,7 +33,7 @@
             android:layout_width="wrap_content"
             android:layout_height="?actionBarSize"
             android:drawableRight="@drawable/ic_arrow_drop_down_white_24dp"
-            android:foreground="?selectableItemBackground"
+            android:background="?selectableItemBackgroundBorderless"
             android:gravity="center"
             android:textColor="?attr/album.selected"
             android:textSize="20sp"/>


### PR DESCRIPTION
Loaders should not be explicitly destroyed while activities are being destroyed, otherwise system framework won't save necessary states for us.

If a user rotated the device or toggled multi window mode, activity will be relaunched, and `onDestroy` lifecycle method will be invoked, and if you destroy the loader explicitly here, after the recreation of activity, loaders will be initialized again, which will lead to another unnecessary data querying.

After my modification, loaders can be retained in such relaunching situations, saving your time. Check it out!

**Apr. 26th 18:17 Updates:**
In *MediaStoreCompat.java*: Use a primitive way that JDK provided to make a File object, avoiding just joining path components manually. And satisfied the linter by fixing some coding style issues.

**Apr. 26th 20:25 Updates:**
Fixed the issue that original version of round-corner image view seems to be not working. To learn more, please review the code I've committed.