### PR TITLE
Refactor SelectionSpecBuilder class

### DIFF
--- a/matisse/src/main/java/com/zhihu/matisse/Matisse.java
+++ b/matisse/src/main/java/com/zhihu/matisse/Matisse.java
@@ -39,6 +39,10 @@ public final class Matisse {
         this(activity, null);
     }
 
+    private Matisse(Fragment fragment) {
+        this(fragment.getActivity(), fragment);
+    }
+
     private Matisse(Activity activity, Fragment fragment) {
         mContext = new WeakReference<>(activity);
         mFragment = new WeakReference<>(fragment);
@@ -67,7 +71,7 @@ public final class Matisse {
      * @return Matisse instance.
      */
     public static Matisse from(Fragment fragment) {
-        return new Matisse(fragment.getActivity(), fragment);
+        return new Matisse(fragment);
     }
 
     /**
@@ -87,12 +91,12 @@ public final class Matisse {
      * Types not included in the set will still be shown in the grid but can't be chosen.
      *
      * @param mimeType MIME types set user can choose from.
-     * @return {@link SelectionSpecBuilder} to build select specifications.
+     * @return {@link SelectionCreator} to build select specifications.
      * @see MimeType
-     * @see SelectionSpecBuilder
+     * @see SelectionCreator
      */
-    public SelectionSpecBuilder choose(Set<MimeType> mimeType) {
-        return new SelectionSpecBuilder(this, mimeType);
+    public SelectionCreator choose(Set<MimeType> mimeType) {
+        return new SelectionCreator(this, mimeType);
     }
 
     @Nullable

--- a/matisse/src/main/java/com/zhihu/matisse/SelectionCreator.java
+++ b/matisse/src/main/java/com/zhihu/matisse/SelectionCreator.java
@@ -224,7 +224,7 @@ public final class SelectionCreator {
      * @return {@link SelectionCreator} for fluent API.
      */
     public SelectionCreator thumbnailScale(float scale) {
-        if (scale < 0f || scale > 1f)
+        if (scale <= 0f || scale > 1f)
             throw new IllegalArgumentException("Thumbnail scale must be between (0.0, 1.0]");
         mSelectionSpec.thumbnailScale = scale;
         return this;

--- a/matisse/src/main/java/com/zhihu/matisse/SelectionCreator.java
+++ b/matisse/src/main/java/com/zhihu/matisse/SelectionCreator.java
@@ -32,12 +32,13 @@ import com.zhihu.matisse.ui.MatisseActivity;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 
 import static android.content.pm.ActivityInfo.SCREEN_ORIENTATION_BEHIND;
 import static android.content.pm.ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR;
+import static android.content.pm.ActivityInfo.SCREEN_ORIENTATION_FULL_USER;
 import static android.content.pm.ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE;
+import static android.content.pm.ActivityInfo.SCREEN_ORIENTATION_LOCKED;
 import static android.content.pm.ActivityInfo.SCREEN_ORIENTATION_NOSENSOR;
 import static android.content.pm.ActivityInfo.SCREEN_ORIENTATION_PORTRAIT;
 import static android.content.pm.ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE;
@@ -49,28 +50,15 @@ import static android.content.pm.ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED;
 import static android.content.pm.ActivityInfo.SCREEN_ORIENTATION_USER;
 import static android.content.pm.ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE;
 import static android.content.pm.ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT;
-import static android.content.pm.ActivityInfo.SCREEN_ORIENTATION_FULL_USER;
-import static android.content.pm.ActivityInfo.SCREEN_ORIENTATION_LOCKED;
 
 /**
  * Fluent API for building media select specification.
  */
 @SuppressWarnings("unused")
-public final class SelectionSpecBuilder {
+public final class SelectionCreator {
     private final Matisse mMatisse;
     private final SelectionSpec mSelectionSpec;
-    private final Set<MimeType> mMimeType;
-    private int mThemeId;
-    private int mOrientation;
-    private boolean mCountable;
-    private int mMaxSelectable;
-    private List<Filter> mFilters;
-    private boolean mCapture;
-    private CaptureStrategy mCaptureStrategy;
-    private int mSpanCount;
-    private int mGridExpectedSize;
-    private float mThumbnailScale;
-    private ImageEngine mImageEngine;
+
 
     @IntDef({
             SCREEN_ORIENTATION_UNSPECIFIED,
@@ -100,11 +88,11 @@ public final class SelectionSpecBuilder {
      * @param matisse  a requester context wrapper.
      * @param mimeType MIME type set to select.
      */
-    SelectionSpecBuilder(Matisse matisse, @NonNull Set<MimeType> mimeType) {
+    SelectionCreator(Matisse matisse, @NonNull Set<MimeType> mimeType) {
         mMatisse = matisse;
-        mMimeType = mimeType;
         mSelectionSpec = SelectionSpec.getCleanInstance();
-        mOrientation = SCREEN_ORIENTATION_UNSPECIFIED;
+        mSelectionSpec.mimeTypeSet = mimeType;
+        mSelectionSpec.orientation = SCREEN_ORIENTATION_UNSPECIFIED;
     }
 
     /**
@@ -116,10 +104,10 @@ public final class SelectionSpecBuilder {
      * you can define a custom theme derived from the above ones or other themes.
      *
      * @param themeId theme resource id. Default value is com.zhihu.matisse.R.style.Matisse_Zhihu.
-     * @return {@link SelectionSpecBuilder} for fluent API.
+     * @return {@link SelectionCreator} for fluent API.
      */
-    public SelectionSpecBuilder theme(@StyleRes int themeId) {
-        mThemeId = themeId;
+    public SelectionCreator theme(@StyleRes int themeId) {
+        mSelectionSpec.themeId = themeId;
         return this;
     }
 
@@ -128,10 +116,10 @@ public final class SelectionSpecBuilder {
      *
      * @param countable true for a auto-increased number from 1, false for a check mark. Default
      *                  value is false.
-     * @return {@link SelectionSpecBuilder} for fluent API.
+     * @return {@link SelectionCreator} for fluent API.
      */
-    public SelectionSpecBuilder countable(boolean countable) {
-        mCountable = countable;
+    public SelectionCreator countable(boolean countable) {
+        mSelectionSpec.countable = countable;
         return this;
     }
 
@@ -139,10 +127,13 @@ public final class SelectionSpecBuilder {
      * Maximum selectable count.
      *
      * @param maxSelectable Maximum selectable count. Default value is 1.
-     * @return {@link SelectionSpecBuilder} for fluent API.
+     * @return {@link SelectionCreator} for fluent API.
+     * @throws IllegalArgumentException if maxSelectable if less than 1.
      */
-    public SelectionSpecBuilder maxSelectable(int maxSelectable) {
-        mMaxSelectable = maxSelectable;
+    public SelectionCreator maxSelectable(int maxSelectable) {
+        if (maxSelectable < 1)
+            throw new IllegalArgumentException("maxSelectable must be greater than or equal to one");
+        mSelectionSpec.maxSelectable = maxSelectable;
         return this;
     }
 
@@ -150,13 +141,15 @@ public final class SelectionSpecBuilder {
      * Add filter to filter each selecting item.
      *
      * @param filter {@link Filter}
-     * @return {@link SelectionSpecBuilder} for fluent API.
+     * @return {@link SelectionCreator} for fluent API.
+     * @throws IllegalArgumentException if filter is null.
      */
-    public SelectionSpecBuilder addFilter(Filter filter) {
-        if (mFilters == null) {
-            mFilters = new ArrayList<>();
+    public SelectionCreator addFilter(@NonNull Filter filter) {
+        if (mSelectionSpec.filters == null) {
+            mSelectionSpec.filters = new ArrayList<>();
         }
-        mFilters.add(filter);
+        if (filter == null) throw new IllegalArgumentException("filter cannot be null");
+        mSelectionSpec.filters.add(filter);
         return this;
     }
 
@@ -166,10 +159,10 @@ public final class SelectionSpecBuilder {
      * If this value is set true, photo capturing entry will appear only on All Media's page.
      *
      * @param enable Whether to enable capturing or not. Default value is false;
-     * @return {@link SelectionSpecBuilder} for fluent API.
+     * @return {@link SelectionCreator} for fluent API.
      */
-    public SelectionSpecBuilder capture(boolean enable) {
-        mCapture = enable;
+    public SelectionCreator capture(boolean enable) {
+        mSelectionSpec.capture = enable;
         return this;
     }
 
@@ -178,10 +171,10 @@ public final class SelectionSpecBuilder {
      * storage and also a authority for {@link android.support.v4.content.FileProvider}.
      *
      * @param captureStrategy {@link CaptureStrategy}, needed only when capturing is enabled.
-     * @return {@link SelectionSpecBuilder} for fluent API.
+     * @return {@link SelectionCreator} for fluent API.
      */
-    public SelectionSpecBuilder captureStrategy(CaptureStrategy captureStrategy) {
-        mCaptureStrategy = captureStrategy;
+    public SelectionCreator captureStrategy(CaptureStrategy captureStrategy) {
+        mSelectionSpec.captureStrategy = captureStrategy;
         return this;
     }
 
@@ -190,11 +183,11 @@ public final class SelectionSpecBuilder {
      *
      * @param orientation An orientation constant as used in {@link ScreenOrientation}.
      *                    Default value is {@link android.content.pm.ActivityInfo#SCREEN_ORIENTATION_PORTRAIT}.
-     * @return {@link SelectionSpecBuilder} for fluent API.
+     * @return {@link SelectionCreator} for fluent API.
      * @see Activity#setRequestedOrientation(int)
      */
-    public SelectionSpecBuilder restrictOrientation(@ScreenOrientation int orientation) {
-        mOrientation = orientation;
+    public SelectionCreator restrictOrientation(@ScreenOrientation int orientation) {
+        mSelectionSpec.orientation = orientation;
         return this;
     }
 
@@ -204,10 +197,12 @@ public final class SelectionSpecBuilder {
      * This will be ignored when {@link #gridExpectedSize(int)} is set.
      *
      * @param spanCount Requested span count.
-     * @return {@link SelectionSpecBuilder} for fluent API.
+     * @return {@link SelectionCreator} for fluent API.
+     * @throws IllegalArgumentException if spanCount is less than 1.
      */
-    public SelectionSpecBuilder spanCount(int spanCount) {
-        mSpanCount = spanCount;
+    public SelectionCreator spanCount(int spanCount) {
+        if (spanCount < 1) throw new IllegalArgumentException("spanCount cannot be less than 1");
+        mSelectionSpec.spanCount = spanCount;
         return this;
     }
 
@@ -217,10 +212,10 @@ public final class SelectionSpecBuilder {
      * size will be as close to this value as possible.
      *
      * @param size Expected media grid size in pixel.
-     * @return {@link SelectionSpecBuilder} for fluent API.
+     * @return {@link SelectionCreator} for fluent API.
      */
-    public SelectionSpecBuilder gridExpectedSize(int size) {
-        mGridExpectedSize = size;
+    public SelectionCreator gridExpectedSize(int size) {
+        mSelectionSpec.gridExpectedSize = size;
         return this;
     }
 
@@ -229,10 +224,13 @@ public final class SelectionSpecBuilder {
      * 1.0].
      *
      * @param scale Thumbnail's scale in (0.0, 1.0]. Default value is 0.5.
-     * @return {@link SelectionSpecBuilder} for fluent API.
+     * @return {@link SelectionCreator} for fluent API.
+     * @throws IllegalArgumentException if scale is less than 0f or greater than 1.0f.
      */
-    public SelectionSpecBuilder thumbnailScale(float scale) {
-        mThumbnailScale = scale;
+    public SelectionCreator thumbnailScale(float scale) {
+        if (scale < 0f || scale > 1f)
+            throw new IllegalArgumentException("Thumbnail scale must be between (0.0, 1.0]");
+        mSelectionSpec.thumbnailScale = scale;
         return this;
     }
 
@@ -245,10 +243,10 @@ public final class SelectionSpecBuilder {
      * And you can implement your own image engine.
      *
      * @param imageEngine {@link ImageEngine}
-     * @return {@link SelectionSpecBuilder} for fluent API.
+     * @return {@link SelectionCreator} for fluent API.
      */
-    public SelectionSpecBuilder imageEngine(ImageEngine imageEngine) {
-        mImageEngine = imageEngine;
+    public SelectionCreator imageEngine(ImageEngine imageEngine) {
+        mSelectionSpec.imageEngine = imageEngine;
         return this;
     }
 
@@ -262,48 +260,6 @@ public final class SelectionSpecBuilder {
         if (activity == null) {
             return;
         }
-
-        mSelectionSpec.mimeTypeSet = mMimeType;
-        if (mThemeId == 0) {
-            mThemeId = R.style.Matisse_Zhihu;
-        }
-        mSelectionSpec.themeId = mThemeId;
-        mSelectionSpec.orientation = mOrientation;
-
-        if (mMaxSelectable <= 1) {
-            mSelectionSpec.countable = false;
-            mSelectionSpec.maxSelectable = 1;
-        } else {
-            mSelectionSpec.countable = mCountable;
-            mSelectionSpec.maxSelectable = mMaxSelectable;
-        }
-
-        if (mFilters != null && mFilters.size() > 0) {
-            mSelectionSpec.filters = mFilters;
-        }
-        mSelectionSpec.capture = mCapture;
-        if (mCapture) {
-            if (mCaptureStrategy == null) {
-                throw new IllegalArgumentException("Don't forget to set CaptureStrategy.");
-            }
-            mSelectionSpec.captureStrategy = mCaptureStrategy;
-        }
-
-        if (mGridExpectedSize > 0) {
-            mSelectionSpec.gridExpectedSize = mGridExpectedSize;
-        } else {
-            mSelectionSpec.spanCount = mSpanCount <= 0 ? 3 : mSpanCount;
-        }
-
-        if (mThumbnailScale < 0 || mThumbnailScale > 1.0f) {
-            throw new IllegalArgumentException("Thumbnail scale must be between (0.0, 1.0]");
-        }
-        if (mThumbnailScale == 0) {
-            mThumbnailScale = 0.5f;
-        }
-        mSelectionSpec.thumbnailScale = mThumbnailScale;
-
-        mSelectionSpec.imageEngine = mImageEngine;
 
         Intent intent = new Intent(activity, MatisseActivity.class);
 

--- a/matisse/src/main/java/com/zhihu/matisse/SelectionCreator.java
+++ b/matisse/src/main/java/com/zhihu/matisse/SelectionCreator.java
@@ -128,7 +128,6 @@ public final class SelectionCreator {
      *
      * @param maxSelectable Maximum selectable count. Default value is 1.
      * @return {@link SelectionCreator} for fluent API.
-     * @throws IllegalArgumentException if maxSelectable if less than 1.
      */
     public SelectionCreator maxSelectable(int maxSelectable) {
         if (maxSelectable < 1)
@@ -142,7 +141,6 @@ public final class SelectionCreator {
      *
      * @param filter {@link Filter}
      * @return {@link SelectionCreator} for fluent API.
-     * @throws IllegalArgumentException if filter is null.
      */
     public SelectionCreator addFilter(@NonNull Filter filter) {
         if (mSelectionSpec.filters == null) {
@@ -198,7 +196,6 @@ public final class SelectionCreator {
      *
      * @param spanCount Requested span count.
      * @return {@link SelectionCreator} for fluent API.
-     * @throws IllegalArgumentException if spanCount is less than 1.
      */
     public SelectionCreator spanCount(int spanCount) {
         if (spanCount < 1) throw new IllegalArgumentException("spanCount cannot be less than 1");
@@ -225,7 +222,6 @@ public final class SelectionCreator {
      *
      * @param scale Thumbnail's scale in (0.0, 1.0]. Default value is 0.5.
      * @return {@link SelectionCreator} for fluent API.
-     * @throws IllegalArgumentException if scale is less than 0f or greater than 1.0f.
      */
     public SelectionCreator thumbnailScale(float scale) {
         if (scale < 0f || scale > 1f)

--- a/matisse/src/main/java/com/zhihu/matisse/filter/Filter.java
+++ b/matisse/src/main/java/com/zhihu/matisse/filter/Filter.java
@@ -18,6 +18,7 @@ package com.zhihu.matisse.filter;
 import android.content.Context;
 
 import com.zhihu.matisse.MimeType;
+import com.zhihu.matisse.SelectionCreator;
 import com.zhihu.matisse.internal.entity.Item;
 import com.zhihu.matisse.internal.entity.IncapableCause;
 
@@ -25,7 +26,7 @@ import java.util.Set;
 
 /**
  * Filter for choosing a {@link Item}. You can add multiple Filters through
- * {@link com.zhihu.matisse.SelectionSpecBuilder#addFilter(Filter)}.
+ * {@link SelectionCreator#addFilter(Filter)}.
  */
 @SuppressWarnings("unused")
 public abstract class Filter {

--- a/matisse/src/main/java/com/zhihu/matisse/internal/entity/SelectionSpec.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/entity/SelectionSpec.java
@@ -20,7 +20,9 @@ import android.content.pm.ActivityInfo;
 import android.support.annotation.StyleRes;
 
 import com.zhihu.matisse.MimeType;
+import com.zhihu.matisse.R;
 import com.zhihu.matisse.engine.ImageEngine;
+import com.zhihu.matisse.engine.impl.GlideEngine;
 import com.zhihu.matisse.filter.Filter;
 
 import java.util.List;
@@ -55,19 +57,19 @@ public final class SelectionSpec {
         return selectionSpec;
     }
 
-    void reset() {
+    private void reset() {
         mimeTypeSet = null;
-        themeId = 0;
+        themeId = R.style.Matisse_Zhihu;
         orientation = 0;
         countable = false;
         maxSelectable = 0;
         filters = null;
         capture = false;
         captureStrategy = null;
-        spanCount = 0;
+        spanCount = 3;
         gridExpectedSize = 0;
-        thumbnailScale = 0.0f;
-        imageEngine = null;
+        thumbnailScale = 0.5f;
+        imageEngine = new GlideEngine();
     }
 
     public boolean needOrientationRestriction() {

--- a/matisse/src/main/java/com/zhihu/matisse/internal/entity/SelectionSpec.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/entity/SelectionSpec.java
@@ -62,7 +62,7 @@ public final class SelectionSpec {
         themeId = R.style.Matisse_Zhihu;
         orientation = 0;
         countable = false;
-        maxSelectable = 0;
+        maxSelectable = 1;
         filters = null;
         capture = false;
         captureStrategy = null;

--- a/matisse/src/main/java/com/zhihu/matisse/internal/ui/MediaSelectionFragment.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/ui/MediaSelectionFragment.java
@@ -99,10 +99,10 @@ public class MediaSelectionFragment extends Fragment implements
 
         int spanCount;
         SelectionSpec selectionSpec = SelectionSpec.getInstance();
-        if (selectionSpec.spanCount > 0) {
-            spanCount = selectionSpec.spanCount;
-        } else {
+        if (selectionSpec.gridExpectedSize > 0) {
             spanCount = UIUtils.spanCount(getContext(), selectionSpec.gridExpectedSize);
+        } else {
+            spanCount = selectionSpec.spanCount;
         }
         mRecyclerView.setLayoutManager(new GridLayoutManager(getContext(), spanCount));
 

--- a/matisse/src/main/java/com/zhihu/matisse/ui/MatisseActivity.java
+++ b/matisse/src/main/java/com/zhihu/matisse/ui/MatisseActivity.java
@@ -88,6 +88,8 @@ public class MatisseActivity extends AppCompatActivity implements
 
         if (spec.capture) {
             mMediaStoreCompat = new MediaStoreCompat(this);
+            if (spec.captureStrategy == null)
+                throw new RuntimeException("Don't forget to set CaptureStrategy.");
             mMediaStoreCompat.setCaptureStrategy(spec.captureStrategy);
         }
 


### PR DESCRIPTION
In my opinion,the class `SelectionSpecBuilder` is not a builder.Similar idea  is found in [Picasso](https://github.com/square/picasso/blob/master/picasso/src/main/java/com/squareup/picasso/RequestCreator.java).

Here is my pr:
* rename `SelectionSpecBuilder`  `SelectionCreator`
* remove a great many attr such as scale,span in `SelectionSpecBuilder`
* prevent user passing illegal attr value such as `maxSelectable = 0` by throwing exception.
* set default value in `SelectionSpec#reset`
