### PR TITLE
delete resize

### DIFF
--- a/matisse/src/main/java/com/zhihu/matisse/engine/ImageEngine.java
+++ b/matisse/src/main/java/com/zhihu/matisse/engine/ImageEngine.java
@@ -31,46 +31,40 @@ public interface ImageEngine {
      * Load thumbnail of a static image resource.
      *
      * @param context     Context
-     * @param resize      Desired size of the origin image
      * @param placeholder Placeholder drawable when image is not loaded yet
      * @param imageView   ImageView widget
      * @param uri         Uri of the loaded image
      */
-    void loadThumbnail(Context context, int resize, Drawable placeholder, ImageView imageView, Uri uri);
+    void loadThumbnail(Context context, Drawable placeholder, ImageView imageView, Uri uri);
 
     /**
      * Load thumbnail of a gif image resource. You don't have to load an animated gif when it's only
      * a thumbnail tile.
      *
      * @param context     Context
-     * @param resize      Desired size of the origin image
      * @param placeholder Placeholder drawable when image is not loaded yet
      * @param imageView   ImageView widget
      * @param uri         Uri of the loaded image
      */
-    void loadAnimatedGifThumbnail(Context context, int resize, Drawable placeholder, ImageView imageView, Uri uri);
+    void loadAnimatedGifThumbnail(Context context, Drawable placeholder, ImageView imageView, Uri uri);
 
     /**
      * Load a static image resource.
      *
      * @param context   Context
-     * @param resizeX   Desired x-size of the origin image
-     * @param resizeY   Desired y-size of the origin image
      * @param imageView ImageView widget
      * @param uri       Uri of the loaded image
      */
-    void loadImage(Context context, int resizeX, int resizeY, ImageView imageView, Uri uri);
+    void loadImage(Context context, ImageView imageView, Uri uri);
 
     /**
      * Load a gif image resource.
      *
      * @param context   Context
-     * @param resizeX   Desired x-size of the origin image
-     * @param resizeY   Desired y-size of the origin image
      * @param imageView ImageView widget
      * @param uri       Uri of the loaded image
      */
-    void loadAnimatedGifImage(Context context, int resizeX, int resizeY, ImageView imageView, Uri uri);
+    void loadAnimatedGifImage(Context context, ImageView imageView, Uri uri);
 
     /**
      * Whether this implementation supports animated gif. Just knowledge of it, convenient for users.

--- a/matisse/src/main/java/com/zhihu/matisse/engine/impl/GlideEngine.java
+++ b/matisse/src/main/java/com/zhihu/matisse/engine/impl/GlideEngine.java
@@ -31,43 +31,39 @@ import com.zhihu.matisse.engine.ImageEngine;
 public class GlideEngine implements ImageEngine {
 
     @Override
-    public void loadThumbnail(Context context, int resize, Drawable placeholder, ImageView imageView, Uri uri) {
+    public void loadThumbnail(Context context, Drawable placeholder, ImageView imageView, Uri uri) {
         Glide.with(context)
                 .load(uri)
                 .asBitmap()  // some .jpeg files are actually gif
                 .placeholder(placeholder)
-                .override(resize, resize)
                 .centerCrop()
                 .into(imageView);
     }
 
     @Override
-    public void loadAnimatedGifThumbnail(Context context, int resize, Drawable placeholder, ImageView imageView,
+    public void loadAnimatedGifThumbnail(Context context, Drawable placeholder, ImageView imageView,
                                          Uri uri) {
         Glide.with(context)
                 .load(uri)
                 .asBitmap()
                 .placeholder(placeholder)
-                .override(resize, resize)
                 .centerCrop()
                 .into(imageView);
     }
 
     @Override
-    public void loadImage(Context context, int resizeX, int resizeY, ImageView imageView, Uri uri) {
+    public void loadImage(Context context, ImageView imageView, Uri uri) {
         Glide.with(context)
                 .load(uri)
-                .override(resizeX, resizeY)
                 .priority(Priority.HIGH)
                 .into(imageView);
     }
 
     @Override
-    public void loadAnimatedGifImage(Context context, int resizeX, int resizeY, ImageView imageView, Uri uri) {
+    public void loadAnimatedGifImage(Context context, ImageView imageView, Uri uri) {
         Glide.with(context)
                 .load(uri)
                 .asGif()
-                .override(resizeX, resizeY)
                 .priority(Priority.HIGH)
                 .into(imageView);
     }

--- a/matisse/src/main/java/com/zhihu/matisse/engine/impl/PicassoEngine.java
+++ b/matisse/src/main/java/com/zhihu/matisse/engine/impl/PicassoEngine.java
@@ -30,28 +30,28 @@ import com.zhihu.matisse.engine.ImageEngine;
 public class PicassoEngine implements ImageEngine {
 
     @Override
-    public void loadThumbnail(Context context, int resize, Drawable placeholder, ImageView imageView, Uri uri) {
+    public void loadThumbnail(Context context, Drawable placeholder, ImageView imageView, Uri uri) {
         Picasso.with(context).load(uri).placeholder(placeholder)
-                .resize(resize, resize)
+                .fit()
                 .centerCrop()
                 .into(imageView);
     }
 
     @Override
-    public void loadAnimatedGifThumbnail(Context context, int resize, Drawable placeholder, ImageView imageView,
+    public void loadAnimatedGifThumbnail(Context context, Drawable placeholder, ImageView imageView,
                                          Uri uri) {
-        loadThumbnail(context, resize, placeholder, imageView, uri);
+        loadThumbnail(context, placeholder, imageView, uri);
     }
 
     @Override
-    public void loadImage(Context context, int resizeX, int resizeY, ImageView imageView, Uri uri) {
-        Picasso.with(context).load(uri).resize(resizeX, resizeY).priority(Picasso.Priority.HIGH)
+    public void loadImage(Context context, ImageView imageView, Uri uri) {
+        Picasso.with(context).load(uri).fit().priority(Picasso.Priority.HIGH)
                 .centerInside().into(imageView);
     }
 
     @Override
-    public void loadAnimatedGifImage(Context context, int resizeX, int resizeY, ImageView imageView, Uri uri) {
-        loadImage(context, resizeX, resizeY, imageView, uri);
+    public void loadAnimatedGifImage(Context context, ImageView imageView, Uri uri) {
+        loadImage(context, imageView, uri);
     }
 
     @Override

--- a/matisse/src/main/java/com/zhihu/matisse/internal/ui/PreviewItemFragment.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/ui/PreviewItemFragment.java
@@ -17,7 +17,6 @@ package com.zhihu.matisse.internal.ui;
 
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
-import android.graphics.Point;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
@@ -29,7 +28,6 @@ import android.widget.Toast;
 import com.zhihu.matisse.R;
 import com.zhihu.matisse.internal.entity.Item;
 import com.zhihu.matisse.internal.entity.SelectionSpec;
-import com.zhihu.matisse.internal.utils.PhotoMetadataUtils;
 
 import it.sephiroth.android.library.imagezoom.ImageViewTouch;
 import it.sephiroth.android.library.imagezoom.ImageViewTouchBase;
@@ -81,12 +79,11 @@ public class PreviewItemFragment extends Fragment {
         ImageViewTouch image = (ImageViewTouch)view.findViewById(R.id.image_view);
         image.setDisplayType(ImageViewTouchBase.DisplayType.FIT_TO_SCREEN);
 
-        Point size = PhotoMetadataUtils.getBitmapSize(item.getContentUri(), getActivity());
         if (item.isGif()) {
-            SelectionSpec.getInstance().imageEngine.loadAnimatedGifImage(getContext(), size.x, size.y, image,
+            SelectionSpec.getInstance().imageEngine.loadAnimatedGifImage(getContext(), image,
                     item.getContentUri());
         } else {
-            SelectionSpec.getInstance().imageEngine.loadImage(getContext(), size.x, size.y, image,
+            SelectionSpec.getInstance().imageEngine.loadImage(getContext(), image,
                     item.getContentUri());
         }
     }

--- a/matisse/src/main/java/com/zhihu/matisse/internal/ui/adapter/AlbumMediaAdapter.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/ui/adapter/AlbumMediaAdapter.java
@@ -49,7 +49,6 @@ public class AlbumMediaAdapter extends
     private CheckStateListener mCheckStateListener;
     private OnMediaClickListener mOnMediaClickListener;
     private RecyclerView mRecyclerView;
-    private int mImageResize;
 
     public AlbumMediaAdapter(Context context, SelectedItemCollection selectedCollection, RecyclerView recyclerView) {
         super(null);
@@ -103,7 +102,6 @@ public class AlbumMediaAdapter extends
 
             final Item item = Item.valueOf(cursor);
             mediaViewHolder.mMediaGrid.preBindMedia(new MediaGrid.PreBindInfo(
-                    getImageResize(mediaViewHolder.mMediaGrid.getContext()),
                     mPlaceholder,
                     mSelectionSpec.countable,
                     holder
@@ -229,19 +227,6 @@ public class AlbumMediaAdapter extends
                 }
             }
         }
-    }
-
-    private int getImageResize(Context context) {
-        if (mImageResize == 0) {
-            RecyclerView.LayoutManager lm = mRecyclerView.getLayoutManager();
-            int spanCount = ((GridLayoutManager) lm).getSpanCount();
-            int screenWidth = context.getResources().getDisplayMetrics().widthPixels;
-            int availableWidth = screenWidth - context.getResources().getDimensionPixelSize(
-                    R.dimen.media_grid_spacing) * (spanCount - 1);
-            mImageResize = availableWidth / spanCount;
-            mImageResize = (int) (mImageResize * mSelectionSpec.thumbnailScale);
-        }
-        return mImageResize;
     }
 
     public interface CheckStateListener {

--- a/matisse/src/main/java/com/zhihu/matisse/internal/ui/adapter/AlbumsAdapter.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/ui/adapter/AlbumsAdapter.java
@@ -67,8 +67,7 @@ public class AlbumsAdapter extends CursorAdapter {
         ((TextView) view.findViewById(R.id.album_media_count)).setText(String.valueOf(album.getCount()));
 
         // do not need to load animated Gif
-        SelectionSpec.getInstance().imageEngine.loadThumbnail(context, context.getResources().getDimensionPixelSize(R
-                        .dimen.media_grid_size), mPlaceholder,
+        SelectionSpec.getInstance().imageEngine.loadThumbnail(context, mPlaceholder,
                 (ImageView) view.findViewById(R.id.album_cover), Uri.fromFile(new File(album.getCoverPath())));
     }
 }

--- a/matisse/src/main/java/com/zhihu/matisse/internal/ui/widget/MediaGrid.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/ui/widget/MediaGrid.java
@@ -111,10 +111,10 @@ public class MediaGrid extends SquareFrameLayout implements View.OnClickListener
 
     private void setImage() {
         if (mMedia.isGif()) {
-            SelectionSpec.getInstance().imageEngine.loadAnimatedGifThumbnail(getContext(), mPreBindInfo.mResize,
+            SelectionSpec.getInstance().imageEngine.loadAnimatedGifThumbnail(getContext(),
                     mPreBindInfo.mPlaceholder, mThumbnail, mMedia.getContentUri());
         } else {
-            SelectionSpec.getInstance().imageEngine.loadThumbnail(getContext(), mPreBindInfo.mResize,
+            SelectionSpec.getInstance().imageEngine.loadThumbnail(getContext(),
                     mPreBindInfo.mPlaceholder, mThumbnail, mMedia.getContentUri());
         }
     }
@@ -144,14 +144,12 @@ public class MediaGrid extends SquareFrameLayout implements View.OnClickListener
     }
 
     public static class PreBindInfo {
-        int mResize;
         Drawable mPlaceholder;
         boolean mCheckViewCountable;
         RecyclerView.ViewHolder mViewHolder;
 
-        public PreBindInfo(int resize, Drawable placeholder, boolean checkViewCountable,
+        public PreBindInfo(Drawable placeholder, boolean checkViewCountable,
                            RecyclerView.ViewHolder viewHolder) {
-            mResize = resize;
             mPlaceholder = placeholder;
             mCheckViewCountable = checkViewCountable;
             mViewHolder = viewHolder;


### PR DESCRIPTION
When I use Matisse With `PicassoEngine`, the result of `loadThumbnail` will be blurry obviously. I find the current implementation uses Picasso's `resize(x, y)` to load images. I replace the method with `fit()`, and the the result of `loadThumbnail` looks better. 

In addition, Glide will load image with the view's size, so I don't think we need `resize(x, y)` or `override(x, y)`, the imageLoader will do a better job.

#### before
![](http://omy50xsvp.bkt.clouddn.com/17-5-2/34326006-file_1493723195252_185ed.jpg?imageView2/0/w/750)

#### after
![](http://omy50xsvp.bkt.clouddn.com/17-5-2/57336113-file_1493723156808_c357.jpg?imageView2/0/w/750)

#### Update
Maybe the source code could tell us the reason: The target of Picasso's `resize(x, y)` is `Bitmap`. For example, if the size of the image we want to load is 1080 height and 720 width, the target view's size is 360 height and 360 width, then Picasso would resize the image to 360 height and 240 width, after `centerCrop()`, the size of image would be 240 height and 240 width. So the image looks blurry.

The target of Glide's `override(x, y)` is `Target`, it would create a `Bitmap` which has a correct size. 

More info in source code : [# ResourceRequestHandler.java](https://github.com/square/picasso/blob/master/picasso/src/main/java/com/squareup/picasso/ResourceRequestHandler.java)