### PR TITLE
Add reaction to album changes

### DIFF
--- a/matisse/src/main/java/com/zhihu/matisse/internal/loader/AlbumLoader.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/loader/AlbumLoader.java
@@ -53,8 +53,11 @@ public class AlbumLoader extends CursorLoader {
     };
     private static final String BUCKET_ORDER_BY = "datetaken DESC";
 
-    public AlbumLoader(Context context) {
+    private OnAlbumContentChangedListener mListener;
+
+    public AlbumLoader(Context context, OnAlbumContentChangedListener listener) {
         super(context, QUERY_URI, PROJECTION, SELECTION, SELECTION_ARGS, BUCKET_ORDER_BY);
+        mListener = listener;
     }
 
     @Override
@@ -79,6 +82,12 @@ public class AlbumLoader extends CursorLoader {
 
     @Override
     public void onContentChanged() {
-        // FIXME a dirty way to fix loading multiple times
+        if (mListener != null) {
+            mListener.onAlbumContentChanged();
+        }
+    }
+
+    public interface OnAlbumContentChangedListener {
+        void onAlbumContentChanged();
     }
 }

--- a/matisse/src/main/java/com/zhihu/matisse/internal/model/AlbumCollection.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/model/AlbumCollection.java
@@ -113,8 +113,9 @@ public class AlbumCollection implements LoaderManager.LoaderCallbacks<Cursor> {
     public void loadAlbums(boolean forceLoad) {
         if (forceLoad) {
             mLoaderManager.restartLoader(LOADER_ID, null, this);
+        } else {
+            mLoaderManager.initLoader(LOADER_ID, null, this);
         }
-        mLoaderManager.initLoader(LOADER_ID, null, this);
     }
 
     public int getCurrentSelection() {

--- a/matisse/src/main/java/com/zhihu/matisse/ui/MatisseActivity.java
+++ b/matisse/src/main/java/com/zhihu/matisse/ui/MatisseActivity.java
@@ -126,6 +126,7 @@ public class MatisseActivity extends AppCompatActivity implements
         mAlbumsSpinner.setSelectedTextView((TextView) findViewById(R.id.selected_album));
         mAlbumsSpinner.setPopupAnchorView(findViewById(R.id.toolbar));
         mAlbumsSpinner.setAdapter(mAlbumsAdapter);
+        mAlbumCollection.setSelectionProvider(this);
         mAlbumCollection.onCreate(this, this);
         mAlbumCollection.onRestoreInstanceState(savedInstanceState);
         mAlbumCollection.loadAlbums();
@@ -262,6 +263,7 @@ public class MatisseActivity extends AppCompatActivity implements
     @Override
     public void onAlbumLoad(final Cursor cursor) {
         mAlbumsAdapter.swapCursor(cursor);
+        updateBottomToolbar();
         // select default album.
         Handler handler = new Handler(Looper.getMainLooper());
         handler.post(new Runnable() {
@@ -326,4 +328,5 @@ public class MatisseActivity extends AppCompatActivity implements
             mMediaStoreCompat.dispatchCaptureIntent(this, REQUEST_CODE_CAPTURE);
         }
     }
+
 }


### PR DESCRIPTION
When user started the picker and go to add/remove some files, the picker would not be aware of this. In this PR, I preliminarily fixed this issue, my strategy to content changes is literally reload anything, and invalidate user's selections. In next stage, maybe we could calculate the diff, and patch the contents.