### PR TITLE
sort album media by date taken

### DIFF
--- a/matisse/src/main/java/com/zhihu/matisse/internal/loader/AlbumMediaLoader.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/loader/AlbumMediaLoader.java
@@ -62,7 +62,7 @@ public class AlbumMediaLoader extends CursorLoader {
                 albumId
         };
     }
-    private static final String ORDER_BY = MediaStore.Files.FileColumns._ID + " DESC";
+    private static final String ORDER_BY = MediaStore.Images.Media.DATE_TAKEN + " DESC";
     private final boolean mEnableCapture;
 
     private AlbumMediaLoader(Context context, Uri uri, String[] projection, String selection, String[] selectionArgs,


### PR DESCRIPTION
In some cases, newer photos not always have bigger ID, sorting by date taken field is more reasonable.

I found this problem on my phone, model Motorola XT1570, android 6.0.1 .
Some photos taken on 2016/12 were listed before newer photos when use Matisse sample , but they were listed with correct order with system gallery, android default image selector or other apps like wechat .

I debugged and found those photos have bigger ID than some newer photos, and this change fixed it.