### PR TITLE
Prevent Matisse to show files with restricted mimetypes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath 'com.novoda:bintray-release:0.4.0'
     }
 }

--- a/matisse/src/main/java/com/zhihu/matisse/SelectionCreator.java
+++ b/matisse/src/main/java/com/zhihu/matisse/SelectionCreator.java
@@ -140,6 +140,11 @@ public final class SelectionCreator {
         return this;
     }
 
+    public SelectionCreator restrictTypes(boolean restrict) {
+        mSelectionSpec.restrictTypes = restrict;
+        return this;
+    }
+
     /**
      * Add filter to filter each selecting item.
      *

--- a/matisse/src/main/java/com/zhihu/matisse/internal/entity/SelectionSpec.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/entity/SelectionSpec.java
@@ -44,6 +44,7 @@ public final class SelectionSpec {
     public int gridExpectedSize;
     public float thumbnailScale;
     public ImageEngine imageEngine;
+    public boolean restrictTypes;
 
     private SelectionSpec() {
     }

--- a/matisse/src/main/java/com/zhihu/matisse/internal/loader/AlbumMediaLoader.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/loader/AlbumMediaLoader.java
@@ -90,8 +90,8 @@ public class AlbumMediaLoader extends CursorLoader {
     public static CursorLoader newInstance(Context context, Album album, boolean capture) {
         if (album.isAll()) {
             SelectionSpec selectionSpec = SelectionSpec.getInstance();
-            if (selectionSpec.restrictTypes &&
-                    selectionSpec.mimeTypeSet.equals(MimeType.ofImage())) {
+
+            if (restrictedToImages(selectionSpec)) {
                 return new AlbumMediaLoader(
                         context,
                         QUERY_URI,
@@ -100,8 +100,7 @@ public class AlbumMediaLoader extends CursorLoader {
                         SELECTION_IMAGE_ARGS,
                         ORDER_BY,
                         capture);
-            } else if(selectionSpec.restrictTypes &&
-                    SelectionSpec.getInstance().mimeTypeSet.equals(MimeType.ofVideo())) {
+            } else if (restrictedToVideos(selectionSpec)) {
                 return new AlbumMediaLoader(
                         context,
                         QUERY_URI,
@@ -110,16 +109,16 @@ public class AlbumMediaLoader extends CursorLoader {
                         SELECTION_VIDEO_ARGS,
                         ORDER_BY,
                         capture);
-            } else {
-                return new AlbumMediaLoader(
-                        context,
-                        QUERY_URI,
-                        PROJECTION,
-                        SELECTION_ALL,
-                        SELECTION_ALL_ARGS,
-                        ORDER_BY,
-                        capture);
             }
+
+            return new AlbumMediaLoader(
+                    context,
+                    QUERY_URI,
+                    PROJECTION,
+                    SELECTION_ALL,
+                    SELECTION_ALL_ARGS,
+                    ORDER_BY,
+                    capture);
         } else {
             return new AlbumMediaLoader(
                     context,
@@ -130,6 +129,16 @@ public class AlbumMediaLoader extends CursorLoader {
                     ORDER_BY,
                     false);
         }
+    }
+
+    private static boolean restrictedToVideos(SelectionSpec selectionSpec) {
+        return selectionSpec.restrictTypes
+                && SelectionSpec.getInstance().mimeTypeSet.equals(MimeType.ofVideo());
+    }
+
+    private static boolean restrictedToImages(SelectionSpec selectionSpec) {
+        return selectionSpec.restrictTypes
+                && selectionSpec.mimeTypeSet.equals(MimeType.ofImage());
     }
 
     @Override

--- a/matisse/src/main/java/com/zhihu/matisse/internal/loader/AlbumMediaLoader.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/loader/AlbumMediaLoader.java
@@ -133,7 +133,7 @@ public class AlbumMediaLoader extends CursorLoader {
 
     private static boolean restrictedToVideos(SelectionSpec selectionSpec) {
         return selectionSpec.restrictTypes
-                && SelectionSpec.getInstance().mimeTypeSet.equals(MimeType.ofVideo());
+                && selectionSpec.mimeTypeSet.equals(MimeType.ofVideo());
     }
 
     private static boolean restrictedToImages(SelectionSpec selectionSpec) {

--- a/matisse/src/main/res/values-pt-rBR/strings.xml
+++ b/matisse/src/main/res/values-pt-rBR/strings.xml
@@ -29,7 +29,7 @@
     <string name="error_over_count">Você só pode selecionar até %1$d arquivos de mídia</string>
     <string name="error_under_quality">Abaixo da qualidade</string>
     <string name="error_over_quality">Acima da qualidade</string>
-    <string name="error_file_type">Este arquivo não pode ser selecionado</string>
+    <string name="error_file_type">Tipo de arquivo não suportado</string>
     <string name="error_type_conflict">Não é possível selecionar arquivos de imagem e vídeo simultaneamente</string>
     <string name="error_no_video_activity">Nenhum player de vídeo disponível para reprodução</string>
 </resources>

--- a/matisse/src/main/res/values-pt-rBR/strings.xml
+++ b/matisse/src/main/res/values-pt-rBR/strings.xml
@@ -29,7 +29,7 @@
     <string name="error_over_count">Você só pode selecionar até %1$d arquivos de mídia</string>
     <string name="error_under_quality">Abaixo da qualidade</string>
     <string name="error_over_quality">Acima da qualidade</string>
-    <string name="error_file_type">Tipo de arquivo não suportado</string>
+    <string name="error_file_type">Este arquivo não pode ser selecionado</string>
     <string name="error_type_conflict">Não é possível selecionar arquivos de imagem e vídeo simultaneamente</string>
     <string name="error_no_video_activity">Nenhum player de vídeo disponível para reprodução</string>
 </resources>

--- a/sample/src/main/java/com/zhihu/matisse/sample/SampleActivity.java
+++ b/sample/src/main/java/com/zhihu/matisse/sample/SampleActivity.java
@@ -79,6 +79,7 @@ public class SampleActivity extends AppCompatActivity implements View.OnClickLis
                                             .choose(MimeType.ofAll(), false)
                                             .countable(true)
                                             .capture(true)
+                                            .restrictTypes(false)
                                             .captureStrategy(
                                                     new CaptureStrategy(true, "com.zhihu.matisse.sample.fileprovider"))
                                             .maxSelectable(9)

--- a/sample/src/main/java/com/zhihu/matisse/sample/SampleActivity.java
+++ b/sample/src/main/java/com/zhihu/matisse/sample/SampleActivity.java
@@ -79,8 +79,8 @@ public class SampleActivity extends AppCompatActivity implements View.OnClickLis
                                             .choose(MimeType.ofAll(), false)
                                             .countable(true)
                                             .capture(true)
-                                            .captureStrategy(new CaptureStrategy(true, "com.zhihu.matisse.sample" +
-                                                    ".fileprovider"))
+                                            .captureStrategy(
+                                                    new CaptureStrategy(true, "com.zhihu.matisse.sample.fileprovider"))
                                             .maxSelectable(9)
                                             .addFilter(new GifSizeFilter(320, 320, 5 * Filter.K * Filter.K))
                                             .gridExpectedSize(

--- a/sample/src/main/res/layout/uri_item.xml
+++ b/sample/src/main/res/layout/uri_item.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
   Copyright 2017 Zhihu Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This is a workaround related to #93 where a filter have been added to AlbumMediaLoader in order to filter mimetypes of video and images and hide them from matisse when used `restrictedTypes(true)`.

This allows Matisse to show/hide general mimetypes depending on the kind restricted programmatically using `choose()` method.