### PR TITLE
Reload contents when activity start

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-25.0.3
+    - build-tools-26.0.0
     - android-25
     - extra-android-m2repository
 

--- a/matisse/build.gradle
+++ b/matisse/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'checkstyle'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    buildToolsVersion "26.0.0"
 
     defaultConfig {
         minSdkVersion 11
@@ -60,7 +60,7 @@ publish {
     website = 'https://www.zhihu.com/'
 }
 
-task checkstyle(type:Checkstyle) {
+task checkstyle(type: Checkstyle) {
     description 'Runs Checkstyle inspection against matisse sourcesets.'
     group = 'Code Quality'
     configFile rootProject.file('checkstyle.xml')

--- a/matisse/src/main/java/com/zhihu/matisse/internal/model/AlbumCollection.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/model/AlbumCollection.java
@@ -99,10 +99,12 @@ public class AlbumCollection implements LoaderManager.LoaderCallbacks<Cursor> {
     }
 
     public void loadAlbums(boolean force) {
-        Loader<?> existingLoader;
-        if (force && (existingLoader = mLoaderManager.getLoader(LOADER_ID)) != null) {
-            existingLoader.forceLoad();
-            return;
+        if (force) {
+            Loader<?> existingLoader = mLoaderManager.getLoader(LOADER_ID);
+            if (existingLoader != null) {
+                existingLoader.forceLoad();
+                return;
+            }
         }
 
         mLoaderManager.initLoader(LOADER_ID, null, this);

--- a/matisse/src/main/java/com/zhihu/matisse/internal/model/AlbumCollection.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/model/AlbumCollection.java
@@ -99,8 +99,9 @@ public class AlbumCollection implements LoaderManager.LoaderCallbacks<Cursor> {
     }
 
     public void loadAlbums(boolean force) {
-        if (force && mLoaderManager.getLoader(LOADER_ID) != null) {
-            mLoaderManager.restartLoader(LOADER_ID, null, this);
+        Loader<?> existingLoader;
+        if (force && (existingLoader = mLoaderManager.getLoader(LOADER_ID)) != null) {
+            existingLoader.forceLoad();
             return;
         }
 

--- a/matisse/src/main/java/com/zhihu/matisse/internal/model/AlbumMediaCollection.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/model/AlbumMediaCollection.java
@@ -98,8 +98,9 @@ public class AlbumMediaCollection implements LoaderManager.LoaderCallbacks<Curso
         args.putParcelable(ARGS_ALBUM, target);
         args.putBoolean(ARGS_ENABLE_CAPTURE, enableCapture);
 
-        if (force && mLoaderManager.getLoader(LOADER_ID) != null) {
-            mLoaderManager.restartLoader(LOADER_ID, args, this);
+        Loader<?> existingLoader;
+        if (force && (existingLoader = mLoaderManager.getLoader(LOADER_ID)) != null) {
+            existingLoader.forceLoad();
             return;
         }
 

--- a/matisse/src/main/java/com/zhihu/matisse/internal/model/AlbumMediaCollection.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/model/AlbumMediaCollection.java
@@ -90,9 +90,19 @@ public class AlbumMediaCollection implements LoaderManager.LoaderCallbacks<Curso
     }
 
     public void load(@Nullable Album target, boolean enableCapture) {
+        load(target, enableCapture, false);
+    }
+
+    public void load(@Nullable Album target, boolean enableCapture, boolean force) {
         Bundle args = new Bundle();
         args.putParcelable(ARGS_ALBUM, target);
         args.putBoolean(ARGS_ENABLE_CAPTURE, enableCapture);
+
+        if (force && mLoaderManager.getLoader(LOADER_ID) != null) {
+            mLoaderManager.restartLoader(LOADER_ID, args, this);
+            return;
+        }
+
         mLoaderManager.initLoader(LOADER_ID, args, this);
     }
 

--- a/matisse/src/main/java/com/zhihu/matisse/internal/model/AlbumMediaCollection.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/model/AlbumMediaCollection.java
@@ -98,10 +98,12 @@ public class AlbumMediaCollection implements LoaderManager.LoaderCallbacks<Curso
         args.putParcelable(ARGS_ALBUM, target);
         args.putBoolean(ARGS_ENABLE_CAPTURE, enableCapture);
 
-        Loader<?> existingLoader;
-        if (force && (existingLoader = mLoaderManager.getLoader(LOADER_ID)) != null) {
-            existingLoader.forceLoad();
-            return;
+        if (force) {
+            Loader<?> existingLoader = mLoaderManager.getLoader(LOADER_ID);
+            if (existingLoader != null) {
+                existingLoader.forceLoad();
+                return;
+            }
         }
 
         mLoaderManager.initLoader(LOADER_ID, args, this);

--- a/matisse/src/main/java/com/zhihu/matisse/internal/model/SelectedItemCollection.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/model/SelectedItemCollection.java
@@ -29,6 +29,7 @@ import com.zhihu.matisse.internal.utils.PathUtils;
 import com.zhihu.matisse.internal.utils.PhotoMetadataUtils;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -135,6 +136,16 @@ public class SelectedItemCollection {
         }
         mItems.clear();
         mItems.addAll(items);
+    }
+
+    public void filterInvalidItems() {
+        Iterator<Item> iterator = mItems.iterator();
+        while (iterator.hasNext()) {
+            final Uri uri = iterator.next().getContentUri();
+            if (PathUtils.getPath(mContext, uri) == null) {
+                iterator.remove();
+            }
+        }
     }
 
 

--- a/matisse/src/main/java/com/zhihu/matisse/internal/model/SelectedItemCollection.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/model/SelectedItemCollection.java
@@ -127,7 +127,7 @@ public class SelectedItemCollection {
         return removed;
     }
 
-    public void overwrite(ArrayList<Item> items, int collectionType) {
+    public void overwrite(List<Item> items, int collectionType) {
         if (items.size() == 0) {
             mCollectionType = COLLECTION_UNDEFINED;
         } else {

--- a/matisse/src/main/java/com/zhihu/matisse/internal/ui/MediaSelectionFragment.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/ui/MediaSelectionFragment.java
@@ -46,6 +46,7 @@ public class MediaSelectionFragment extends Fragment implements
     private RecyclerView mRecyclerView;
     private AlbumMediaAdapter mAdapter;
     private SelectionProvider mSelectionProvider;
+    private Album mAlbum;
     private AlbumMediaAdapter.CheckStateListener mCheckStateListener;
     private AlbumMediaAdapter.OnMediaClickListener mOnMediaClickListener;
 
@@ -73,6 +74,13 @@ public class MediaSelectionFragment extends Fragment implements
         }
     }
 
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        mAlbum = getArguments().getParcelable(EXTRA_ALBUM);
+    }
+
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
@@ -89,7 +97,6 @@ public class MediaSelectionFragment extends Fragment implements
     @Override
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-        Album album = getArguments().getParcelable(EXTRA_ALBUM);
 
         mAdapter = new AlbumMediaAdapter(getContext(),
                 mSelectionProvider.provideSelectedItemCollection(), mRecyclerView);
@@ -110,7 +117,7 @@ public class MediaSelectionFragment extends Fragment implements
         mRecyclerView.addItemDecoration(new MediaGridInset(spanCount, spacing, false));
         mRecyclerView.setAdapter(mAdapter);
         mAlbumMediaCollection.onCreate(getActivity(), this);
-        mAlbumMediaCollection.load(album, selectionSpec.capture);
+        mAlbumMediaCollection.load(mAlbum, selectionSpec.capture);
     }
 
     @Override
@@ -151,6 +158,15 @@ public class MediaSelectionFragment extends Fragment implements
             mOnMediaClickListener.onMediaClick((Album) getArguments().getParcelable(EXTRA_ALBUM),
                     item, adapterPosition);
         }
+    }
+
+    public Album getAlbum() {
+        return mAlbum;
+    }
+
+    public void reloadContents() {
+        SelectionSpec selectionSpec = SelectionSpec.getInstance();
+        mAlbumMediaCollection.load(mAlbum, selectionSpec.capture, true);
     }
 
     public interface SelectionProvider {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    buildToolsVersion "26.0.0"
 
     defaultConfig {
         applicationId 'com.zhihu.matisse.sample'


### PR DESCRIPTION
This is a workaround for the enhancement I proposed in #85 .

It basically reloads anything when activity is started, and find out whether the selections are valid. If an album user previously selected is not existed after reloading, we will navigate to the initial album.

For now, I simply clear all selections when contents changed.