### PR TITLE
Fix wrong "equals" implementation

### DIFF
--- a/matisse/src/main/java/com/zhihu/matisse/internal/entity/Item.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/entity/Item.java
@@ -132,7 +132,13 @@ public class Item implements Parcelable {
         }
 
         Item other = (Item) obj;
-        return other.uri.equals(uri);
+        return id == other.id
+                && (mimeType != null && mimeType.equals(other.mimeType)
+                    || (mimeType == null && other.mimeType == null))
+                && (uri != null && uri.equals(other.uri)
+                    || (uri == null && other.uri == null))
+                && size == other.size
+                && duration == other.duration;
     }
 
     @Override


### PR DESCRIPTION
The original implementation didn't meet following requirement:

> if `Object#equals()` return true, then two object's `Object#hashCode()` must be equal.

The issue may not be obvious now, but it can cause potential problems and not good for future extendibility.

If we want to choose `Item#uri` as the only key, then we need to modify the `hashCode` method. 