### PR TITLE
Create engine that works with GlideV4 RC

### DIFF
--- a/matisse/src/main/java/com/zhihu/matisse/engine/impl/GlideV4Engine
+++ b/matisse/src/main/java/com/zhihu/matisse/engine/impl/GlideV4Engine
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 Zhihu Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zhihu.matisse.engine.impl;
+
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.net.Uri;
+import android.widget.ImageView;
+
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.Priority;
+import com.zhihu.matisse.engine.ImageEngine;
+
+/**
+ * {@link ImageEngine} implementation using Glide.
+ */
+
+public class GlideEngine implements ImageEngine {
+
+    @Override
+    public void loadThumbnail(Context context, int resize, Drawable placeholder, ImageView imageView, Uri uri) {
+        RequestOptions options = new RequestOptions().placeholder(placeholder).override(resize, resize).centerCrop();
+        Glide.with(context)
+                .asBitmap()  // some .jpeg files are actually gif
+                .load(uri)
+                .apply(options)
+                .into(imageView);
+    }
+
+    @Override
+    public void loadGifThumbnail(Context context, int resize, Drawable placeholder, ImageView imageView,
+                                 Uri uri) {
+        RequestOptions options = new RequestOptions().placeholder(placeholder).override(resize, resize).centerCrop();
+        Glide.with(context)
+                .asBitmap()
+                .load(uri)
+                .apply(options)
+                .into(imageView);
+    }
+
+    @Override
+    public void loadImage(Context context, int resizeX, int resizeY, ImageView imageView, Uri uri) {
+        RequestOptions options = new RequestOptions().override(resizeX, resizeY).priority(Priority.HIGH);
+        Glide.with(context)
+                .load(uri)
+                .apply(options)
+                .into(imageView);
+    }
+
+    @Override
+    public void loadGifImage(Context context, int resizeX, int resizeY, ImageView imageView, Uri uri) {
+        RequestOptions options = new RequestOptions().override(resizeX, resizeY).priority(Priority.HIGH);
+        Glide.with(context)
+                .asGif()
+                .load(uri)
+                .apply(options)
+                .into(imageView);
+    }
+
+    @Override
+    public boolean supportAnimatedGif() {
+        return true;
+    }
+
+}


### PR DESCRIPTION
Glide 4 will change handling of methods and put them inside a RequestOptions object: https://bumptech.github.io/glide/doc/migrating.html 

I took the GlideEngine.java file and applied the changes needed to make it work with Glide V4