### PR TITLE
Fix wrong drawable filtering

### DIFF
--- a/matisse/src/main/java/com/zhihu/matisse/internal/ui/adapter/AlbumMediaAdapter.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/ui/adapter/AlbumMediaAdapter.java
@@ -93,11 +93,22 @@ public class AlbumMediaAdapter extends
                     new int[]{R.attr.capture_textColor});
             int color = ta.getColor(0, 0);
             ta.recycle();
-            for (Drawable drawable : drawables) {
+
+            for (int i = 0; i < drawables.length; i++) {
+                Drawable drawable = drawables[i];
                 if (drawable != null) {
-                    drawable.setColorFilter(color, PorterDuff.Mode.SRC_IN);
+                    final Drawable.ConstantState state = drawable.getConstantState();
+                    if (state == null) {
+                        continue;
+                    }
+
+                    Drawable newDrawable = state.newDrawable().mutate();
+                    newDrawable.setColorFilter(color, PorterDuff.Mode.SRC_IN);
+                    newDrawable.setBounds(drawable.getBounds());
+                    drawables[i] = newDrawable;
                 }
             }
+            captureViewHolder.mHint.setCompoundDrawables(drawables[0], drawables[1], drawables[2], drawables[3]);
         } else if (holder instanceof MediaViewHolder) {
             MediaViewHolder mediaViewHolder = (MediaViewHolder) holder;
 


### PR DESCRIPTION
This code will fix issue with wrong filtering compound drawables. 
When you have another `ic_photo_camera_white_24dp` in main project, it may lead to undefined behaviour when you will try to use it after Matisse (probably, filtered image, or probably not).