### PR TITLE
Support Library updates, upgraded to Glide v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ Check out [Matisse releases](https://github.com/zhihu/Matisse/releases) to see m
 If you use [Glide](https://github.com/bumptech/glide) as your image engine, add rules as Glide's README says.  
 And add extra rule:
 ```pro
--dontwarn com.squareup.picasso.**
+-dontwarn com.bumptech.glide.**
 ```
 
 If you use [Picasso](https://github.com/square/picasso) as your image engine, add rules as Picasso's README says.  
 And add extra rule:
 ```pro
--dontwarn com.bumptech.glide.**
+-dontwarn com.squareup.picasso.**
 ```
 
 ## How do I use Matisse?

--- a/build.gradle
+++ b/build.gradle
@@ -17,16 +17,18 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:3.0.0-beta3'
         classpath 'com.novoda:bintray-release:0.5.0'
     }
 }
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Apr 07 20:01:34 CST 2017
+#Tue Aug 29 18:31:15 IST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/matisse/build.gradle
+++ b/matisse/build.gradle
@@ -18,12 +18,12 @@ apply plugin: 'com.novoda.bintray-release'
 apply plugin: 'checkstyle'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.1"
 
     defaultConfig {
         minSdkVersion 11
-        targetSdkVersion 25
+        targetSdkVersion 26
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
@@ -34,19 +34,18 @@ android {
     }
 }
 
-ext.supportLibVersion = '25.3.1'
+ext.supportLibVersion = '26.0.1'
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-
-    compile "com.android.support:support-v4:${supportLibVersion}"
-    compile "com.android.support:appcompat-v7:${supportLibVersion}"
-    compile "com.android.support:support-annotations:${supportLibVersion}"
-    compile "com.android.support:recyclerview-v7:${supportLibVersion}"
-    compile 'it.sephiroth.android.library.imagezoom:library:1.0.4'
-
-    provided 'com.github.bumptech.glide:glide:3.7.0'
-    provided 'com.squareup.picasso:picasso:2.5.2'
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    implementation "com.android.support:support-v4:${supportLibVersion}"
+    implementation "com.android.support:appcompat-v7:${supportLibVersion}"
+    implementation "com.android.support:support-annotations:${supportLibVersion}"
+    implementation "com.android.support:design:${supportLibVersion}"
+    implementation "com.android.support:recyclerview-v7:${supportLibVersion}"
+    implementation 'it.sephiroth.android.library.imagezoom:library:1.0.4'
+    implementation 'com.github.bumptech.glide:glide:3.7.0'
+    implementation 'com.squareup.picasso:picasso:2.5.2'
 }
 
 // jcenter configuration for novoda's bintray-release

--- a/matisse/src/main/java/com/zhihu/matisse/engine/impl/GlideEngine.java
+++ b/matisse/src/main/java/com/zhihu/matisse/engine/impl/GlideEngine.java
@@ -22,6 +22,7 @@ import android.widget.ImageView;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.Priority;
+import com.bumptech.glide.request.RequestOptions;
 import com.zhihu.matisse.engine.ImageEngine;
 
 /**
@@ -32,44 +33,42 @@ public class GlideEngine implements ImageEngine {
 
     @Override
     public void loadThumbnail(Context context, int resize, Drawable placeholder, ImageView imageView, Uri uri) {
+        RequestOptions options = new RequestOptions().placeholder(placeholder).override(resize, resize).centerCrop();
         Glide.with(context)
-                .load(uri)
-                .asBitmap()  // some .jpeg files are actually gif
-                .placeholder(placeholder)
-                .override(resize, resize)
-                .centerCrop()
-                .into(imageView);
+            .asBitmap()  // some .jpeg files are actually gif
+            .load(uri)
+            .apply(options)
+            .into(imageView);
     }
 
     @Override
     public void loadGifThumbnail(Context context, int resize, Drawable placeholder, ImageView imageView,
-                                 Uri uri) {
+        Uri uri) {
+        RequestOptions options = new RequestOptions().placeholder(placeholder).override(resize, resize).centerCrop();
         Glide.with(context)
-                .load(uri)
-                .asBitmap()
-                .placeholder(placeholder)
-                .override(resize, resize)
-                .centerCrop()
-                .into(imageView);
+            .asBitmap()
+            .load(uri)
+            .apply(options)
+            .into(imageView);
     }
 
     @Override
     public void loadImage(Context context, int resizeX, int resizeY, ImageView imageView, Uri uri) {
+        RequestOptions options = new RequestOptions().override(resizeX, resizeY).priority(Priority.HIGH);
         Glide.with(context)
-                .load(uri)
-                .override(resizeX, resizeY)
-                .priority(Priority.HIGH)
-                .into(imageView);
+            .load(uri)
+            .apply(options)
+            .into(imageView);
     }
 
     @Override
     public void loadGifImage(Context context, int resizeX, int resizeY, ImageView imageView, Uri uri) {
+        RequestOptions options = new RequestOptions().override(resizeX, resizeY).priority(Priority.HIGH);
         Glide.with(context)
-                .load(uri)
-                .asGif()
-                .override(resizeX, resizeY)
-                .priority(Priority.HIGH)
-                .into(imageView);
+            .asGif()
+            .load(uri)
+            .apply(options)
+            .into(imageView);
     }
 
     @Override

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -16,13 +16,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.1"
 
     defaultConfig {
         applicationId 'com.zhihu.matisse.sample'
         minSdkVersion 11
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }
@@ -36,12 +36,13 @@ android {
 }
 
 dependencies {
-    compile project(':matisse')
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation project(':matisse')
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.tbruyelle.rxpermissions2:rxpermissions:0.9.1@aar'
-    compile 'io.reactivex.rxjava2:rxjava:2.0.5'
-    compile 'com.github.bumptech.glide:glide:3.7.0'
-    compile 'com.squareup.picasso:picasso:2.5.2'
+    implementation 'com.android.support:appcompat-v7:26.0.1'
+    implementation 'com.android.support:recyclerview-v7:26.0.1'
+    implementation 'com.tbruyelle.rxpermissions2:rxpermissions:0.9.4@aar'
+    implementation 'io.reactivex.rxjava2:rxjava:2.1.3'
+    implementation 'com.github.bumptech.glide:glide:3.7.0'
+    implementation 'com.squareup.picasso:picasso:2.5.2'
 }


### PR DESCRIPTION
Branchout as develop because of support libraries-glide major version bump. Updated support libraries to 26.0.1, upgraded glide to v4, fixed GlideEngine. Tested on real device.