### PR TITLE
Add API: SelectionCreator.maxSelectablePerMediaType()

### DIFF
--- a/matisse/src/main/java/com/zhihu/matisse/SelectionCreator.java
+++ b/matisse/src/main/java/com/zhihu/matisse/SelectionCreator.java
@@ -148,7 +148,26 @@ public final class SelectionCreator {
     public SelectionCreator maxSelectable(int maxSelectable) {
         if (maxSelectable < 1)
             throw new IllegalArgumentException("maxSelectable must be greater than or equal to one");
+        if (mSelectionSpec.maxImageSelectable > 0 || mSelectionSpec.maxVideoSelectable > 0)
+            throw new IllegalStateException("already set maxImageSelectable and maxVideoSelectable");
         mSelectionSpec.maxSelectable = maxSelectable;
+        return this;
+    }
+
+    /**
+     * Only useful when {@link SelectionSpec#mediaTypeExclusive} set true and you want to set different maximum
+     * selectable files for image and video media types.
+     *
+     * @param maxImageSelectable Maximum selectable count for image.
+     * @param maxVideoSelectable Maximum selectable count for video.
+     * @return
+     */
+    public SelectionCreator maxSelectablePerMediaType(int maxImageSelectable, int maxVideoSelectable) {
+        if (maxImageSelectable < 1 || maxVideoSelectable < 1)
+            throw new IllegalArgumentException(("max selectable must be greater than or equal to one"));
+        mSelectionSpec.maxSelectable = -1;
+        mSelectionSpec.maxImageSelectable = maxImageSelectable;
+        mSelectionSpec.maxVideoSelectable = maxVideoSelectable;
         return this;
     }
 

--- a/matisse/src/main/java/com/zhihu/matisse/internal/entity/SelectionSpec.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/entity/SelectionSpec.java
@@ -38,6 +38,8 @@ public final class SelectionSpec {
     public int orientation;
     public boolean countable;
     public int maxSelectable;
+    public int maxImageSelectable;
+    public int maxVideoSelectable;
     public List<Filter> filters;
     public boolean capture;
     public CaptureStrategy captureStrategy;
@@ -67,6 +69,8 @@ public final class SelectionSpec {
         orientation = 0;
         countable = false;
         maxSelectable = 1;
+        maxImageSelectable = 0;
+        maxVideoSelectable = 0;
         filters = null;
         capture = false;
         captureStrategy = null;
@@ -77,7 +81,7 @@ public final class SelectionSpec {
     }
 
     public boolean singleSelectionModeEnabled() {
-        return !countable && maxSelectable == 1;
+        return !countable && (maxSelectable == 1 || (maxImageSelectable == 1 && maxVideoSelectable == 1));
     }
 
     public boolean needOrientationRestriction() {

--- a/matisse/src/main/java/com/zhihu/matisse/internal/model/SelectedItemCollection.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/model/SelectedItemCollection.java
@@ -168,7 +168,7 @@ public class SelectedItemCollection {
 
     public IncapableCause isAcceptable(Item item) {
         if (maxSelectableReached()) {
-            int maxSelectable = SelectionSpec.getInstance().maxSelectable;
+            int maxSelectable = currentMaxSelectable();
             String cause;
 
             try {
@@ -193,7 +193,21 @@ public class SelectedItemCollection {
     }
 
     public boolean maxSelectableReached() {
-        return mItems.size() == SelectionSpec.getInstance().maxSelectable;
+        return mItems.size() == currentMaxSelectable();
+    }
+
+    // depends
+    private int currentMaxSelectable() {
+        SelectionSpec spec = SelectionSpec.getInstance();
+        if (spec.maxSelectable > 0) {
+            return spec.maxSelectable;
+        } else if (mCollectionType == COLLECTION_IMAGE) {
+            return spec.maxImageSelectable;
+        } else if (mCollectionType == COLLECTION_VIDEO) {
+            return spec.maxVideoSelectable;
+        } else {
+            return spec.maxSelectable;
+        }
     }
 
     public int getCollectionType() {


### PR DESCRIPTION
Thus, we can set different maximum selectable number for image and video media types.