### PR TITLE
Preserves Captured Uri and Path value in orientation change.

### DIFF
--- a/matisse/src/main/java/com/zhihu/matisse/internal/utils/MediaStoreCompat.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/utils/MediaStoreCompat.java
@@ -22,6 +22,7 @@ import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.os.Build;
+import android.os.Bundle;
 import android.os.Environment;
 import android.provider.MediaStore;
 import android.support.v4.app.Fragment;
@@ -39,6 +40,8 @@ import java.util.List;
 import java.util.Locale;
 
 public class MediaStoreCompat {
+    public static final String STATE_PHOTO_URI = "state_photo_uri";
+    public static final String STATE_PHOTO_PATH = "state_photo_path";
 
     private final WeakReference<Activity> mContext;
     private final WeakReference<Fragment> mFragment;
@@ -135,5 +138,19 @@ public class MediaStoreCompat {
 
     public String getCurrentPhotoPath() {
         return mCurrentPhotoPath;
+    }
+
+    public void onRestoreInstanceState(Bundle savedInstanceState) {
+        if (savedInstanceState == null) {
+            return;
+        }
+
+        mCurrentPhotoUri = savedInstanceState.getParcelable(STATE_PHOTO_URI);
+        mCurrentPhotoPath = savedInstanceState.getString(STATE_PHOTO_PATH);
+    }
+
+    public void onSaveInstanceState(Bundle outState) {
+        outState.putParcelable(STATE_PHOTO_URI, mCurrentPhotoUri);
+        outState.putString(STATE_PHOTO_PATH, mCurrentPhotoPath);
     }
 }

--- a/matisse/src/main/java/com/zhihu/matisse/ui/MatisseActivity.java
+++ b/matisse/src/main/java/com/zhihu/matisse/ui/MatisseActivity.java
@@ -98,6 +98,7 @@ public class MatisseActivity extends AppCompatActivity implements
             if (mSpec.captureStrategy == null)
                 throw new RuntimeException("Don't forget to set CaptureStrategy.");
             mMediaStoreCompat.setCaptureStrategy(mSpec.captureStrategy);
+            mMediaStoreCompat.onRestoreInstanceState(savedInstanceState);
         }
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
@@ -137,6 +138,7 @@ public class MatisseActivity extends AppCompatActivity implements
         super.onSaveInstanceState(outState);
         mSelectedCollection.onSaveInstanceState(outState);
         mAlbumCollection.onSaveInstanceState(outState);
+        mMediaStoreCompat.onSaveInstanceState(outState);
     }
 
     @Override
@@ -272,14 +274,16 @@ public class MatisseActivity extends AppCompatActivity implements
 
             @Override
             public void run() {
-                cursor.moveToPosition(mAlbumCollection.getCurrentSelection());
-                mAlbumsSpinner.setSelection(MatisseActivity.this,
-                        mAlbumCollection.getCurrentSelection());
-                Album album = Album.valueOf(cursor);
-                if (album.isAll() && SelectionSpec.getInstance().capture) {
-                    album.addCaptureCount();
+                if (!cursor.isClosed()) {
+                    cursor.moveToPosition(mAlbumCollection.getCurrentSelection());
+                    mAlbumsSpinner.setSelection(MatisseActivity.this,
+                          mAlbumCollection.getCurrentSelection());
+                    Album album = Album.valueOf(cursor);
+                    if (album.isAll() && SelectionSpec.getInstance().capture) {
+                        album.addCaptureCount();
+                    }
+                    onAlbumSelected(album);
                 }
-                onAlbumSelected(album);
             }
         });
     }


### PR DESCRIPTION
Due to the default orientation of the camera application, 
it preserves the Captured Uri and Path value in the configuration change (orientation)

E.g., Galaxy Note 2(Android 4.4.2, API 19) camera app


```
12-04 14:14:09.121 8778-8778/com.zhihu.matisse.sample E/AndroidRuntime: FATAL EXCEPTION: main
  Process: com.zhihu.matisse.sample, PID: 8778
  java.lang.RuntimeException: Unable to resume activity {com.zhihu.matisse.sample/com.zhihu.matisse.ui.MatisseActivity}: java.lang.RuntimeException: Failure delivering result ResultInfo{who=null, request=24, result=-1, data=null} to activity {com.zhihu.matisse.sample/com.zhihu.matisse.ui.MatisseActivity}: java.lang.NullPointerException
      at android.app.ActivityThread.performResumeActivity(ActivityThread.java:3076)
      at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:3105)
      at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2476)
      at android.app.ActivityThread.handleRelaunchActivity(ActivityThread.java:4054)
      at android.app.ActivityThread.access$1000(ActivityThread.java:175)
      at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1314)
      at android.os.Handler.dispatchMessage(Handler.java:102)
      at android.os.Looper.loop(Looper.java:146)
      at android.app.ActivityThread.main(ActivityThread.java:5602)
      at java.lang.reflect.Method.invokeNative(Native Method)
      at java.lang.reflect.Method.invoke(Method.java:515)
      at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1283)
      at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1099)
      at dalvik.system.NativeStart.main(Native Method)
   Caused by: java.lang.RuntimeException: Failure delivering result ResultInfo{who=null, request=24, result=-1, data=null} to activity {com.zhihu.matisse.sample/com.zhihu.matisse.ui.MatisseActivity}: java.lang.NullPointerException
      at android.app.ActivityThread.deliverResults(ActivityThread.java:3681)
      at android.app.ActivityThread.performResumeActivity(ActivityThread.java:3063)
      at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:3105) 
      at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2476) 
      at android.app.ActivityThread.handleRelaunchActivity(ActivityThread.java:4054) 
      at android.app.ActivityThread.access$1000(ActivityThread.java:175) 
      at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1314) 
      at android.os.Handler.dispatchMessage(Handler.java:102) 
      at android.os.Looper.loop(Looper.java:146) 
      at android.app.ActivityThread.main(ActivityThread.java:5602) 
      at java.lang.reflect.Method.invokeNative(Native Method) 
      at java.lang.reflect.Method.invoke(Method.java:515) 
      at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1283) 
      at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1099) 
      at dalvik.system.NativeStart.main(Native Method) 
   Caused by: java.lang.NullPointerException
      at android.app.ActivityManagerProxy.revokeUriPermission(ActivityManagerNative.java:4079)
      at android.app.ContextImpl.revokeUriPermission(ContextImpl.java:2237)
      at android.content.ContextWrapper.revokeUriPermission(ContextWrapper.java:594)
      at com.zhihu.matisse.ui.MatisseActivity.onActivityResult(MatisseActivity.java:210)
      at android.app.Activity.dispatchActivityResult(Activity.java:5643)
      at android.app.ActivityThread.deliverResults(ActivityThread.java:3677)
      at android.app.ActivityThread.performResumeActivity(ActivityThread.java:3063) 
      at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:3105) 
      at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2476) 
      at android.app.ActivityThread.handleRelaunchActivity(ActivityThread.java:4054) 
      at android.app.ActivityThread.access$1000(ActivityThread.java:175) 
      at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1314) 
      at android.os.Handler.dispatchMessage(Handler.java:102) 
      at android.os.Looper.loop(Looper.java:146) 
      at android.app.ActivityThread.main(ActivityThread.java:5602) 
      at java.lang.reflect.Method.invokeNative(Native Method) 
      at java.lang.reflect.Method.invoke(Method.java:515) 
      at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1283) 
      at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1099) 
      at dalvik.system.NativeStart.main(Native Method) 
```