### PR TITLE
Allow CaptureStrategy to specify Pictures subdirectory

### DIFF
--- a/matisse/src/main/java/com/zhihu/matisse/internal/entity/CaptureStrategy.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/entity/CaptureStrategy.java
@@ -19,9 +19,15 @@ public class CaptureStrategy {
 
     public final boolean isPublic;
     public final String authority;
+    public final String directory;
 
     public CaptureStrategy(boolean isPublic, String authority) {
+        this(isPublic, authority, null);
+    }
+
+    public CaptureStrategy(boolean isPublic, String authority, String directory) {
         this.isPublic = isPublic;
         this.authority = authority;
+        this.directory = directory;
     }
 }

--- a/matisse/src/main/java/com/zhihu/matisse/internal/utils/MediaStoreCompat.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/utils/MediaStoreCompat.java
@@ -117,6 +117,9 @@ public class MediaStoreCompat {
         } else {
             storageDir = mContext.get().getExternalFilesDir(Environment.DIRECTORY_PICTURES);
         }
+        if (mCaptureStrategy.directory != null) {
+            storageDir = new File(storageDir, mCaptureStrategy.directory);
+        }
 
         // Avoid joining path components manually
         File tempFile = new File(storageDir, imageFileName);


### PR DESCRIPTION
Our app currently stores captured images in a subfolder of the Pictures directory, similar to Hangouts, Facebook Messenger, etc. do it. To retain this behaviour, this patch adds an optional "directory" property to the CaptureStrategy, which if non-null gets appended to the path.

Ideally we would also like to customize the filename template, but I'm unsure how much customization you would want to allow there.