### PR TITLE
Fix about 'ProGuard' explain in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,15 @@ Check out [Matisse releases](https://github.com/zhihu/Matisse/releases) to see m
 If you use [Glide](https://github.com/bumptech/glide) as your image engine, add rules as Glide's README says.  
 And add extra rule:
 ```pro
--dontwarn com.squareup.picasso.**
+-dontwarn com.bumptech.glide.**
 ```
 
 If you use [Picasso](https://github.com/square/picasso) as your image engine, add rules as Picasso's README says.  
 And add extra rule:
 ```pro
--dontwarn com.bumptech.glide.**
+-dontwarn com.squareup.picasso.**
 ```
-**Attention**: The above progurad rules are correct.
+**Attention**: The above proguard rules are correct.
 
 ## How do I use Matisse?
 #### Permission


### PR DESCRIPTION
I think 'ProGuard' codes in README.md are upside down.
So I fix just three lines in README.md file
 