### PR TITLE
Runtime STORAGE Permission problem

### DIFF
--- a/matisse/src/main/java/com/zhihu/matisse/internal/ui/AlbumPreviewActivity.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/ui/AlbumPreviewActivity.java
@@ -15,6 +15,8 @@
  */
 package com.zhihu.matisse.internal.ui;
 
+import android.Manifest;
+import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -40,7 +42,10 @@ public class AlbumPreviewActivity extends BasePreviewActivity implements
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
+        if (checkCallingOrSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_DENIED) {
+            finish();
+            return;
+        }
         mCollection.onCreate(this, this);
         Album album = getIntent().getParcelableExtra(EXTRA_ALBUM);
         mCollection.load(album);
@@ -57,7 +62,8 @@ public class AlbumPreviewActivity extends BasePreviewActivity implements
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        mCollection.onDestroy();
+        if (checkCallingOrSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED)
+            mCollection.onDestroy();
     }
 
     @Override

--- a/matisse/src/main/java/com/zhihu/matisse/internal/ui/BasePreviewActivity.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/ui/BasePreviewActivity.java
@@ -15,8 +15,10 @@
  */
 package com.zhihu.matisse.internal.ui;
 
+import android.Manifest;
 import android.app.Activity;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.view.ViewPager;
@@ -59,6 +61,11 @@ public abstract class BasePreviewActivity extends AppCompatActivity implements V
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         setTheme(SelectionSpec.getInstance().themeId);
         super.onCreate(savedInstanceState);
+        if (checkCallingOrSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_DENIED) {
+            setResult(RESULT_CANCELED);
+            finish();
+            return;
+        }
         setContentView(R.layout.activity_media_preview);
         if (Platform.hasKitKat()) {
             getWindow().addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);

--- a/matisse/src/main/java/com/zhihu/matisse/internal/ui/SelectedPreviewActivity.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/ui/SelectedPreviewActivity.java
@@ -15,6 +15,8 @@
  */
 package com.zhihu.matisse.internal.ui;
 
+import android.Manifest;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 
@@ -28,6 +30,10 @@ public class SelectedPreviewActivity extends BasePreviewActivity {
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        if (checkCallingOrSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_DENIED) {
+            finish();
+            return;
+        }
 
         Bundle bundle = getIntent().getBundleExtra(EXTRA_DEFAULT_BUNDLE);
         List<Item> selected = bundle.getParcelableArrayList(SelectedItemCollection.STATE_SELECTION);

--- a/matisse/src/main/java/com/zhihu/matisse/ui/MatisseActivity.java
+++ b/matisse/src/main/java/com/zhihu/matisse/ui/MatisseActivity.java
@@ -15,8 +15,10 @@
  */
 package com.zhihu.matisse.ui;
 
+import android.Manifest;
 import android.app.Activity;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.content.res.TypedArray;
 import android.database.Cursor;
 import android.graphics.PorterDuff;
@@ -86,6 +88,10 @@ public class MatisseActivity extends AppCompatActivity implements
         mSpec = SelectionSpec.getInstance();
         setTheme(mSpec.themeId);
         super.onCreate(savedInstanceState);
+        if (checkCallingOrSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_DENIED) {
+            finish();
+            return;
+        }
 
         setContentView(R.layout.activity_matisse);
 
@@ -142,7 +148,8 @@ public class MatisseActivity extends AppCompatActivity implements
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        mAlbumCollection.onDestroy();
+        if (checkCallingOrSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED)
+            mAlbumCollection.onDestroy();
     }
 
     @Override

--- a/matisse/src/main/res/values/strings.xml
+++ b/matisse/src/main/res/values/strings.xml
@@ -18,8 +18,8 @@
     <string name="album_name_all">All Media</string>
 
     <string name="button_preview">Preview</string>
-    <string name="button_apply_default">Apply</string>
-    <string name="button_apply">Apply(%1$d)</string>
+    <string name="button_apply_default">Done</string>
+    <string name="button_apply">Done(%1$d)</string>
     <string name="button_back">Back</string>
     <string name="photo_grid_capture">Camera</string>
     <string name="empty_text">No media yet</string>


### PR DESCRIPTION
Handle runtime permission crash when user revokes STORAGE permission (MatisseActivity, PreviewActiviry). String 'Apply' changed to 'Done'