### PR TITLE
修复AlbumsSpinner下拉第一次图像不显示bug

### DIFF
--- a/matisse/src/main/java/com/zhihu/matisse/internal/ui/widget/RoundedRectangleImageView.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/ui/widget/RoundedRectangleImageView.java
@@ -53,7 +53,7 @@ public class RoundedRectangleImageView extends AppCompatImageView {
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-        mRectF.set(0.0f, 0.0f, getWidth(), getHeight());
+        mRectF.set(0.0f, 0.0f, getMeasuredWidth(), getMeasuredHeight());
         mRoundedRectPath.addRoundRect(mRectF, mRadius, mRadius, Path.Direction.CW);
     }
 


### PR DESCRIPTION
使用com.nostra13.universalimageloader.core.ImageLoader加载图片时，第一次选择相册，下拉中的相册图片不能正常加载。