### PR TITLE
fix bug: cursor closed while Activity onResume

### DIFF
--- a/matisse/src/main/java/com/zhihu/matisse/internal/model/AlbumMediaCollection.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/model/AlbumMediaCollection.java
@@ -61,6 +61,9 @@ public class AlbumMediaCollection implements LoaderManager.LoaderCallbacks<Curso
             return;
         }
 
+        if (data.isClosed()) {
+            return;
+        }
         mCallbacks.onAlbumMediaLoad(data);
     }
 


### PR DESCRIPTION
解决播放视频 crash 问题:
进入选择视频的页面,点击播放视频,在播放过程中点击返回,会 crash.
是由于 cursor 已关闭造成的.