### PR TITLE
Fix: Crash caused by android.database.StaleDataException.

### DIFF
--- a/matisse/src/main/java/com/zhihu/matisse/internal/ui/AlbumPreviewActivity.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/ui/AlbumPreviewActivity.java
@@ -68,25 +68,23 @@ public class AlbumPreviewActivity extends BasePreviewActivity implements
     @Override
     public void onAlbumMediaLoad(Cursor cursor) {
         List<Item> items = new ArrayList<>();
-        while (cursor.moveToNext()) {
-            items.add(Item.valueOf(cursor));
+        if (!cursor.isClosed()) {
+            while (cursor.moveToNext()) {
+                items.add(Item.valueOf(cursor));
+            }
         }
-//        cursor.close();
-
-        if (items.isEmpty()) {
-            return;
-        }
-
-        PreviewPagerAdapter adapter = (PreviewPagerAdapter) mPager.getAdapter();
-        adapter.addAll(items);
-        adapter.notifyDataSetChanged();
-        if (!mIsAlreadySetPosition) {
-            //onAlbumMediaLoad is called many times..
-            mIsAlreadySetPosition = true;
-            Item selected = getIntent().getParcelableExtra(EXTRA_ITEM);
-            int selectedIndex = items.indexOf(selected);
-            mPager.setCurrentItem(selectedIndex, false);
-            mPreviousPos = selectedIndex;
+        if (!items.isEmpty()) {
+            PreviewPagerAdapter adapter = (PreviewPagerAdapter) mPager.getAdapter();
+            adapter.addAll(items);
+            adapter.notifyDataSetChanged();
+            if (!mIsAlreadySetPosition) {
+                //onAlbumMediaLoad is called many times..
+                mIsAlreadySetPosition = true;
+                Item selected = getIntent().getParcelableExtra(EXTRA_ITEM);
+                int selectedIndex = items.indexOf(selected);
+                mPager.setCurrentItem(selectedIndex, false);
+                mPreviousPos = selectedIndex;
+            }
         }
     }
 


### PR DESCRIPTION
### :dart: What is the goal?

Avoid crash caused by android.database.StaleDataException.

Fatal Exception: java.lang.RuntimeException: Unable to resume activity {.../com.zhihu.matisse.internal.ui.AlbumPreviewActivity}: android.database.StaleDataException: Attempted to access a cursor after it has been closed.
       at android.app.ActivityThread.performResumeActivity(ActivityThread.java:3675)
       at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:3715)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1653)
       at android.os.Handler.dispatchMessage(Handler.java:105)
       at android.os.Looper.loop(Looper.java:169)
       at android.app.ActivityThread.main(ActivityThread.java:6578)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.Zygote$MethodAndArgsCaller.run(Zygote.java:240)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:767)

### :memo: How is it being implemented?

Checking if the cursor is closed.