### PR TITLE
Make sure directory in capture strategy exists before proceeding

### DIFF
--- a/matisse/src/main/java/com/zhihu/matisse/internal/utils/MediaStoreCompat.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/utils/MediaStoreCompat.java
@@ -121,6 +121,7 @@ public class MediaStoreCompat {
         }
         if (mCaptureStrategy.directory != null) {
             storageDir = new File(storageDir, mCaptureStrategy.directory);
+            if (!storageDir.exists()) storageDir.mkdirs();
         }
 
         // Avoid joining path components manually


### PR DESCRIPTION
#### Motivation

Since Matisse supports changing the dir where the captured pictures are saved into, the directory may NOT exist. 

Thus we should call `mkdirs()` to make it if it does not exist.