### PR TITLE
修改toolbar命名空间

### DIFF
--- a/matisse/src/main/res/layout/activity_matisse.xml
+++ b/matisse/src/main/res/layout/activity_matisse.xml
@@ -26,9 +26,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="?colorPrimary"
-        android:elevation="4dp"
         android:theme="?toolbar"
-        tools:targetApi="lollipop">
+        app:elevation="4dp">
 
         <TextView
             android:id="@+id/selected_album"


### PR DESCRIPTION
activity_matisse.xml里用了Support包里的ToolBar，但是Elevation属性没有使用自定义命名空间，而是用默认命名空间，这在api>21的手机上会存在潜在问题。

因项目需求，需要对布局进行修改。然后发现ToolBar会遮挡与之层叠的View，经过研究发现是这个命名空间导致的。