### PR TITLE
Fix for https://github.com/zhihu/Matisse/issues/446

### DIFF
--- a/matisse/src/main/java/com/zhihu/matisse/internal/model/SelectedItemCollection.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/model/SelectedItemCollection.java
@@ -169,25 +169,12 @@ public class SelectedItemCollection {
     public IncapableCause isAcceptable(Item item) {
         if (maxSelectableReached()) {
             int maxSelectable = currentMaxSelectable();
-            String cause;
 
-            try {
-                cause = mContext.getResources().getQuantityString(
-                        R.plurals.error_over_count,
-                        maxSelectable,
-                        maxSelectable
-                );
-            } catch (Resources.NotFoundException e) {
-                cause = mContext.getString(
-                        R.string.error_over_count,
-                        maxSelectable
-                );
-            } catch (NoClassDefFoundError e) {
-                cause = mContext.getString(
-                        R.string.error_over_count,
-                        maxSelectable
-                );
-            }
+            String cause = mContext.getResources().getQuantityString(
+                    R.plurals.error_over_count,
+                    maxSelectable,
+                    maxSelectable
+            );
 
             return new IncapableCause(cause);
         } else if (typeConflict(item)) {

--- a/matisse/src/main/res/values-ar/strings.xml
+++ b/matisse/src/main/res/values-ar/strings.xml
@@ -11,7 +11,14 @@
     <string name="button_ok">تم</string>
 
     <string name="error_over_count_default">لقد وصلت إلى الحد الأقصى للاختيار</string>
-    <string name="error_over_count">يمكنك تحديد ما يصل إلى %1$d من ملفات الوسائط فقط</string>
+    <plurals name="error_over_count">
+        <item quantity="few">يمكنك تحديد ما يصل إلى %1$d من ملفات الوسائط فقط</item>
+        <item quantity="many">يمكنك تحديد ما يصل إلى %1$d من ملفات الوسائط فقط</item>
+        <item quantity="one">يمكنك تحديد ما يصل إلى %1$d من ملفات الوسائط فقط</item>
+        <item quantity="two">يمكنك تحديد ما يصل إلى %1$d من ملفات الوسائط فقط</item>
+        <item quantity="zero">يمكنك تحديد ما يصل إلى %1$d من ملفات الوسائط فقط</item>
+        <item quantity="other">يمكنك تحديد ما يصل إلى %1$d من ملفات الوسائط فقط</item>
+    </plurals>
     <string name="error_under_quality">تحت الجودة</string>
     <string name="error_over_quality">فوق الجودة</string>
     <string name="error_file_type">نوع ملف غير مدعوم</string>

--- a/matisse/src/main/res/values-ca/strings.xml
+++ b/matisse/src/main/res/values-ca/strings.xml
@@ -26,7 +26,10 @@
     <string name="button_ok">OK</string>
 
     <string name="error_over_count_default">Has sobrepassat el màxim d\'arxius seleccionables</string>
-    <string name="error_over_count">Només pots seleccionar fins a %1$d arxius multimedia</string>
+    <plurals name="error_over_count">
+        <item quantity="one">Només pots seleccionar fins a %1$d arxius multimedia</item>
+        <item quantity="other">Només pots seleccionar fins a %1$d arxius multimedia</item>
+    </plurals>
     <string name="error_under_quality">Baixa qualitat</string>
     <string name="error_over_quality">Excés qualitat</string>
     <string name="error_file_type">Tipus d\'arxiu no permés</string>

--- a/matisse/src/main/res/values-de/strings.xml
+++ b/matisse/src/main/res/values-de/strings.xml
@@ -23,7 +23,10 @@
     <string name="button_ok">OK</string>
 
     <string name="error_over_count_default">Sie haben die maximale Anzahl an Medien ausgewählt.</string>
-    <string name="error_over_count">Sie können nur %1$d Medien auswählen</string>
+    <plurals name="error_over_count">
+        <item quantity="one">Sie können nur %1$d Medien auswählen</item>
+        <item quantity="other">Sie können nur %1$d Medien auswählen</item>
+    </plurals>
     <string name="error_under_quality">Unter Qualität</string>
     <string name="error_over_quality">Über Qualität</string>
     <string name="error_file_type">Dateityp nicht unterstützt</string>

--- a/matisse/src/main/res/values-es/strings.xml
+++ b/matisse/src/main/res/values-es/strings.xml
@@ -26,7 +26,10 @@
     <string name="button_ok">OK</string>
 
     <string name="error_over_count_default">Has alcanzado el máximo de archivos seleccionables</string>
-    <string name="error_over_count">Sólo puede seleccionar hasta %1$d archivos multimedia</string>
+    <plurals name="error_over_count">
+        <item quantity="one">Sólo puede seleccionar hasta %1$d archivos multimedia</item>
+        <item quantity="other">Sólo puede seleccionar hasta %1$d archivos multimedia</item>
+    </plurals>
     <string name="error_under_quality">Baja calidad</string>
     <string name="error_over_quality">Exceso calidad</string>
     <string name="error_file_type">Tipo de fichero no soportado</string>

--- a/matisse/src/main/res/values-it/strings.xml
+++ b/matisse/src/main/res/values-it/strings.xml
@@ -26,7 +26,10 @@
     <string name="button_ok">OK</string>
 
     <string name="error_over_count_default">Hai selezionato il numero massimo di elementi</string>
-    <string name="error_over_count">Puoi selezionare fino a %1$d elementi</string>
+    <plurals name="error_over_count">
+        <item quantity="one">Puoi selezionare fino a %1$d elementi</item>
+        <item quantity="other">Puoi selezionare fino a %1$d elementi</item>
+    </plurals>
     <string name="error_under_quality">Sotto qualità</string>
     <string name="error_over_quality">Sopra qualità</string>
     <string name="error_file_type">Tipo di file non supportato</string>

--- a/matisse/src/main/res/values-ko/strings.xml
+++ b/matisse/src/main/res/values-ko/strings.xml
@@ -11,7 +11,9 @@
   <string name="empty_text">미디어 파일이 없습니다.</string>
   <string name="button_ok">확인</string>
   <string name="error_over_count_default">더이상 선택할 수 없습니다.</string>
-  <string name="error_over_count">최대 %1$d까지 선택 가능합니다.</string>
+  <plurals name="error_over_count">
+    <item quantity="other">최대 %1$d까지 선택 가능합니다.</item>
+  </plurals>
   <string name="error_under_quality">화질이 너무 낮습니다.</string>
   <string name="error_over_quality">화질이 너무 높습니다.</string>
   <string name="error_file_type">지원되지 않는 파일 유형입니다.</string>

--- a/matisse/src/main/res/values-pl/strings.xml
+++ b/matisse/src/main/res/values-pl/strings.xml
@@ -26,7 +26,12 @@
     <string name="button_ok">OK</string>
 
     <string name="error_over_count_default">Osiągnąłeś limit wybieralnych elementów</string>
-    <string name="error_over_count">Możesz wybrać do %1$d plików</string>
+    <plurals name="error_over_count">
+        <item quantity="few">Możesz wybrać do %1$d plików</item>
+        <item quantity="many">Możesz wybrać do %1$d plików</item>
+        <item quantity="one">Możesz wybrać do %1$d plików</item>
+        <item quantity="other">Możesz wybrać do %1$d plików</item>
+    </plurals>
     <string name="error_under_quality">Poniżej jakości</string>
     <string name="error_over_quality">Powyżej jakości</string>
     <string name="error_file_type">Niewspierany typ pliku</string>

--- a/matisse/src/main/res/values-pt-rBR/strings.xml
+++ b/matisse/src/main/res/values-pt-rBR/strings.xml
@@ -26,7 +26,10 @@
     <string name="button_ok">OK</string>
 
     <string name="error_over_count_default">Você atingiu o máximo de itens possíveis para seleção</string>
-    <string name="error_over_count">Você só pode selecionar até %1$d arquivos de mídia</string>
+    <plurals name="error_over_count">
+        <item quantity="one">Você só pode selecionar até %1$d arquivos de mídia</item>
+        <item quantity="other">Você só pode selecionar até %1$d arquivos de mídia</item>
+    </plurals>
     <string name="error_under_quality">Abaixo da qualidade</string>
     <string name="error_over_quality">Acima da qualidade</string>
     <string name="error_file_type">Tipo de arquivo não suportado</string>

--- a/matisse/src/main/res/values-tr-rTR/strings.xml
+++ b/matisse/src/main/res/values-tr-rTR/strings.xml
@@ -26,7 +26,10 @@
     <string name="button_ok">TAMAM</string>
 
     <string name="error_over_count_default">Maksimum seçilebilir değere ulaştınız</string>
-    <string name="error_over_count">Sadece %1$d medya dosyasını seçebilirsiniz</string>
+    <plurals name="error_over_count">
+        <item quantity="one">Sadece %1$d medya dosyasını seçebilirsiniz</item>
+        <item quantity="other">Sadece %1$d medya dosyasını seçebilirsiniz</item>
+    </plurals>
     <string name="error_under_quality">Düşük kalite</string>
     <string name="error_over_quality">Yüksek kalite</string>
     <string name="error_file_type">Desteklenmeyen dosya tipi</string>

--- a/matisse/src/main/res/values-zh-rTW/strings.xml
+++ b/matisse/src/main/res/values-zh-rTW/strings.xml
@@ -26,7 +26,9 @@
     <string name="button_ok">我知道了</string>
 
     <string name="error_over_count_default">您已經達到最大選擇數量</string>
-    <string name="error_over_count">最多只能選擇 %1$d 個文件</string>
+    <plurals name="error_over_count">
+        <item quantity="other">最多只能選擇 %1$d 個文件</item>
+    </plurals>
     <string name="error_under_quality">圖片質量太低</string>
     <string name="error_over_quality">圖片質量太高</string>
     <string name="error_file_type">不支援的文件類型</string>

--- a/matisse/src/main/res/values-zh/strings.xml
+++ b/matisse/src/main/res/values-zh/strings.xml
@@ -26,7 +26,9 @@
     <string name="button_ok">我知道了</string>
 
     <string name="error_over_count_default">您已经达到最大选择数量</string>
-    <string name="error_over_count">最多只能选择 %1$d 个文件</string>
+    <plurals name="error_over_count">
+        <item quantity="other">最多只能选择 %1$d 个文件</item>
+    </plurals>
     <string name="error_under_quality">图片质量太低</string>
     <string name="error_over_quality">图片质量太高</string>
     <string name="error_file_type">不支持的文件类型</string>

--- a/matisse/src/main/res/values/strings.xml
+++ b/matisse/src/main/res/values/strings.xml
@@ -28,7 +28,10 @@
     <string name="button_ok">OK</string>
 
     <string name="error_over_count_default">You have reached max selectable</string>
-    <string name="error_over_count">You can only select up to %1$d media files</string>
+    <plurals name="error_over_count">
+        <item quantity="one">You can only select up to 1 media file</item>
+        <item quantity="other">You can only select up to %1$d media files</item>
+    </plurals>
     <string name="error_under_quality">Under quality</string>
     <string name="error_over_quality">Over quality</string>
     <string name="error_file_type">Unsupported file type</string>


### PR DESCRIPTION
May I suggest the fix for issue https://github.com/zhihu/Matisse/issues/446

We need to get back to affected translators, to revise fields for `one`, `two`, `other`, ... Currently, I just made them all same.