### PR TITLE
Ok string

### DIFF
--- a/matisse/src/main/java/com/zhihu/matisse/internal/ui/BasePreviewActivity.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/ui/BasePreviewActivity.java
@@ -271,14 +271,14 @@ public abstract class BasePreviewActivity extends AppCompatActivity implements V
     private void updateApplyButton() {
         int selectedCount = mSelectedCollection.count();
         if (selectedCount == 0) {
-            mButtonApply.setText(R.string.button_sure_default);
+            mButtonApply.setText(android.R.string.ok);
             mButtonApply.setEnabled(false);
         } else if (selectedCount == 1 && mSpec.singleSelectionModeEnabled()) {
-            mButtonApply.setText(R.string.button_sure_default);
+            mButtonApply.setText(android.R.string.ok);
             mButtonApply.setEnabled(true);
         } else {
             mButtonApply.setEnabled(true);
-            mButtonApply.setText(getString(R.string.button_sure, selectedCount));
+            mButtonApply.setText(getString(R.string.button_ok_template, getString(android.R.string.ok), selectedCount));
         }
 
         if (mSpec.originalable) {

--- a/matisse/src/main/java/com/zhihu/matisse/ui/MatisseActivity.java
+++ b/matisse/src/main/java/com/zhihu/matisse/ui/MatisseActivity.java
@@ -244,15 +244,15 @@ public class MatisseActivity extends AppCompatActivity implements
         if (selectedCount == 0) {
             mButtonPreview.setEnabled(false);
             mButtonApply.setEnabled(false);
-            mButtonApply.setText(getString(R.string.button_sure_default));
+            mButtonApply.setText(android.R.string.ok);
         } else if (selectedCount == 1 && mSpec.singleSelectionModeEnabled()) {
             mButtonPreview.setEnabled(true);
-            mButtonApply.setText(R.string.button_sure_default);
+            mButtonApply.setText(android.R.string.ok);
             mButtonApply.setEnabled(true);
         } else {
             mButtonPreview.setEnabled(true);
             mButtonApply.setEnabled(true);
-            mButtonApply.setText(getString(R.string.button_sure, selectedCount));
+            mButtonApply.setText(getString(R.string.button_ok_template, getString(android.R.string.ok), selectedCount));
         }
 
 

--- a/matisse/src/main/res/values-pl/strings.xml
+++ b/matisse/src/main/res/values-pl/strings.xml
@@ -33,6 +33,4 @@
     <string name="error_type_conflict">Nie można wybierać obrazów i filmów w tym samym czasie</string>
     <string name="error_no_video_activity">Nie znaleziono aplikacji wspierającej podgląd wideo</string>
     <string name="button_original">Oryginał</string>
-    <string name="button_sure_default">Zatwierdź</string>
-    <string name="button_sure">Zatwierdź(%1$d)</string>
 </resources>

--- a/matisse/src/main/res/values-ru/strings.xml
+++ b/matisse/src/main/res/values-ru/strings.xml
@@ -38,6 +38,4 @@
     <string name="error_type_conflict">Невозможно выбрать изображения и видео одновременно</string>
     <string name="error_no_video_activity">Приложение для предпросмотра видео не найдено</string>
     <string name="button_original">Оригинал</string>
-    <string name="button_sure">Применить(%1$d)</string>
-    <string name="button_sure_default">Применить</string>
 </resources>

--- a/matisse/src/main/res/values-zh-rTW/strings.xml
+++ b/matisse/src/main/res/values-zh-rTW/strings.xml
@@ -33,6 +33,4 @@
     <string name="error_type_conflict">不能同時選擇圖片和影片</string>
     <string name="error_no_video_activity">沒有支持影片預覽的應用程式</string>
     <string name="button_original">原圖</string>
-    <string name="button_sure_default">确定</string>
-    <string name="button_sure">确定(%1$d)</string>
 </resources>

--- a/matisse/src/main/res/values-zh/strings.xml
+++ b/matisse/src/main/res/values-zh/strings.xml
@@ -35,6 +35,4 @@
     <string name="error_over_original_size">"该照片大于 %1$d M，无法上传将取消勾选原图"</string>
     <string name="error_over_original_count">"有 %1$d 张照片大于 %2$d M\n无法上传，将取消勾选原图"</string>
     <string name="button_original">原图</string>
-    <string name="button_sure_default">确定</string>
-    <string name="button_sure">确定(%1$d)</string>
 </resources>

--- a/matisse/src/main/res/values/strings.xml
+++ b/matisse/src/main/res/values/strings.xml
@@ -37,6 +37,5 @@
     <string name="error_over_original_size">Can\'t select the images larger than %1$d MB</string>
     <string name="error_over_original_count">%1$d images over %2$d MB. Original will be unchecked</string>
     <string name="button_original">Original</string>
-    <string name="button_sure_default">Sure</string>
-    <string name="button_sure">Sure(%1$d)</string>
+    <string name="button_ok_template" translatable="false">%1$s (%2$d)</string>
 </resources>


### PR DESCRIPTION
Instead of defined "Sure" string manually, I guess it gave a better UX outcome, as most users familiar with system defined "OK" - `android.R.string.ok`