### PR TITLE
Support wildcard of subtypes on checking item mime type

### DIFF
--- a/matisse/src/main/java/com/zhihu/matisse/MimeType.java
+++ b/matisse/src/main/java/com/zhihu/matisse/MimeType.java
@@ -114,6 +114,21 @@ public enum MimeType {
         return EnumSet.of(MPEG, MP4, QUICKTIME, THREEGPP, THREEGPP2, MKV, WEBM, TS, AVI);
     }
 
+    public static boolean isImage(String mimeType) {
+        if (mimeType == null) return false;
+        return mimeType.startsWith("image");
+    }
+
+    public static boolean isVideo(String mimeType) {
+        if (mimeType == null) return false;
+        return mimeType.startsWith("video");
+    }
+
+    public static boolean isGif(String mimeType) {
+        if (mimeType == null) return false;
+        return mimeType.equals(MimeType.GIF.toString());
+    }
+
     private static Set<String> arraySetOf(String... suffixes) {
         return new ArraySet<>(Arrays.asList(suffixes));
     }

--- a/matisse/src/main/java/com/zhihu/matisse/internal/entity/Item.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/entity/Item.java
@@ -102,30 +102,15 @@ public class Item implements Parcelable {
     }
 
     public boolean isImage() {
-        if (mimeType == null) return false;
-        return mimeType.equals(MimeType.JPEG.toString())
-                || mimeType.equals(MimeType.PNG.toString())
-                || mimeType.equals(MimeType.GIF.toString())
-                || mimeType.equals(MimeType.BMP.toString())
-                || mimeType.equals(MimeType.WEBP.toString());
+        return MimeType.isImage(mimeType);
     }
 
     public boolean isGif() {
-        if (mimeType == null) return false;
-        return mimeType.equals(MimeType.GIF.toString());
+        return MimeType.isGif(mimeType);
     }
 
     public boolean isVideo() {
-        if (mimeType == null) return false;
-        return mimeType.equals(MimeType.MPEG.toString())
-                || mimeType.equals(MimeType.MP4.toString())
-                || mimeType.equals(MimeType.QUICKTIME.toString())
-                || mimeType.equals(MimeType.THREEGPP.toString())
-                || mimeType.equals(MimeType.THREEGPP2.toString())
-                || mimeType.equals(MimeType.MKV.toString())
-                || mimeType.equals(MimeType.WEBM.toString())
-                || mimeType.equals(MimeType.TS.toString())
-                || mimeType.equals(MimeType.AVI.toString());
+        return MimeType.isVideo(mimeType);
     }
 
     @Override


### PR DESCRIPTION
### 修改理由
在判断 Image item 类型的时候，只判断 mime 的 type，不判断 `subtype`，以支持 `image/*` , `video/*` 的特殊情况。

不这么做的话，在选择了一个媒体的时候，对 `MimeType` 为 `image/*` 的图片，就不会纳入计数里，导致可以出现这样的问题：在只允许选择一张图并且指定只能为 `jpg`, `png`, `gif`, `webp` 的情况下，用户可以同时选中一张 `image/*` 和 `image/jpg` 的图。