### PR TITLE
FIX style item.checkCircle.backgroundColor not work with original CheckRadioView && FIX CheckStyle && fix sumsung take photo crash bug:configuration changed cause MediaStoreCompat uri and path cleaned

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
     "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 
 <module name="Checker">

--- a/matisse/src/main/java/com/zhihu/matisse/internal/ui/widget/CheckRadioView.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/ui/widget/CheckRadioView.java
@@ -1,6 +1,7 @@
 package com.zhihu.matisse.internal.ui.widget;
 
 import android.content.Context;
+import android.content.res.TypedArray;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.support.v4.content.res.ResourcesCompat;
@@ -21,17 +22,22 @@ public class CheckRadioView extends AppCompatImageView {
         init();
     }
 
-
-
     public CheckRadioView(Context context, AttributeSet attrs) {
         super(context, attrs);
         init();
     }
 
+    public CheckRadioView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init();
+    }
+
     private void init() {
-        mSelectedColor = ResourcesCompat.getColor(
-                getResources(), R.color.zhihu_item_checkCircle_backgroundColor,
-                getContext().getTheme());
+        TypedArray ta = getContext().getTheme()
+                .obtainStyledAttributes(new int[]{R.attr.item_checkCircle_backgroundColor});
+        mSelectedColor = ta.getColor(0,
+                ResourcesCompat.getColor(getResources(), R.color.zhihu_item_checkCircle_backgroundColor, getContext().getTheme()));
+        ta.recycle();
         mUnSelectUdColor = ResourcesCompat.getColor(
                 getResources(), R.color.zhihu_check_original_radio_disable,
                 getContext().getTheme());

--- a/matisse/src/main/java/com/zhihu/matisse/internal/utils/MediaStoreCompat.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/utils/MediaStoreCompat.java
@@ -62,6 +62,10 @@ public class MediaStoreCompat {
     }
 
     public void onSaveInstanceState(Bundle outState) {
+        if (outState == null) {
+            return;
+        }
+
         if (mCurrentPhotoUri != null) {
             outState.putString(MEDIA_STORE_COMPAT_CUR_PHOTO_URI, mCurrentPhotoUri.toString());
         }

--- a/matisse/src/main/java/com/zhihu/matisse/internal/utils/MediaStoreCompat.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/utils/MediaStoreCompat.java
@@ -22,11 +22,13 @@ import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.os.Build;
+import android.os.Bundle;
 import android.os.Environment;
 import android.provider.MediaStore;
 import android.support.v4.app.Fragment;
 import android.support.v4.content.FileProvider;
 import android.support.v4.os.EnvironmentCompat;
+import android.text.TextUtils;
 
 import com.zhihu.matisse.internal.entity.CaptureStrategy;
 
@@ -40,11 +42,14 @@ import java.util.Locale;
 
 public class MediaStoreCompat {
 
+    public static final String MEDIA_STORE_COMPAT_CUR_PHOTO_URI = "media_store_compat_cur_photo_uri";
+    public static final String MEDIA_STORE_COMPAT_CUR_PHOTO_PATH = "media_store_compat_cur_photo_path";
+
     private final WeakReference<Activity> mContext;
     private final WeakReference<Fragment> mFragment;
-    private       CaptureStrategy         mCaptureStrategy;
-    private       Uri                     mCurrentPhotoUri;
-    private       String                  mCurrentPhotoPath;
+    private CaptureStrategy mCaptureStrategy;
+    private Uri mCurrentPhotoUri;
+    private String mCurrentPhotoPath;
 
     public MediaStoreCompat(Activity activity) {
         mContext = new WeakReference<>(activity);
@@ -54,6 +59,23 @@ public class MediaStoreCompat {
     public MediaStoreCompat(Activity activity, Fragment fragment) {
         mContext = new WeakReference<>(activity);
         mFragment = new WeakReference<>(fragment);
+    }
+
+    public void onSaveInstanceState(Bundle outState) {
+        if (mCurrentPhotoUri != null) {
+            outState.putString(MEDIA_STORE_COMPAT_CUR_PHOTO_URI, mCurrentPhotoUri.toString());
+        }
+        outState.putString(MEDIA_STORE_COMPAT_CUR_PHOTO_PATH, mCurrentPhotoPath);
+    }
+
+    public void onCreate(Bundle savedInstanceState) {
+        if (savedInstanceState != null) {
+            mCurrentPhotoPath = savedInstanceState.getString(MEDIA_STORE_COMPAT_CUR_PHOTO_PATH, null);
+            String uriStr = savedInstanceState.getString(MEDIA_STORE_COMPAT_CUR_PHOTO_URI, null);
+            if (!TextUtils.isEmpty(uriStr)) {
+                mCurrentPhotoUri = Uri.parse(uriStr);
+            }
+        }
     }
 
     /**

--- a/matisse/src/main/java/com/zhihu/matisse/ui/MatisseActivity.java
+++ b/matisse/src/main/java/com/zhihu/matisse/ui/MatisseActivity.java
@@ -158,7 +158,9 @@ public class MatisseActivity extends AppCompatActivity implements
         super.onSaveInstanceState(outState);
         mSelectedCollection.onSaveInstanceState(outState);
         mAlbumCollection.onSaveInstanceState(outState);
-        mMediaStoreCompat.onSaveInstanceState(outState);
+        if (mMediaStoreCompat != null) {
+            mMediaStoreCompat.onSaveInstanceState(outState);
+        }
         outState.putBoolean("checkState", mOriginalEnable);
     }
 

--- a/matisse/src/main/java/com/zhihu/matisse/ui/MatisseActivity.java
+++ b/matisse/src/main/java/com/zhihu/matisse/ui/MatisseActivity.java
@@ -112,6 +112,7 @@ public class MatisseActivity extends AppCompatActivity implements
             if (mSpec.captureStrategy == null)
                 throw new RuntimeException("Don't forget to set CaptureStrategy.");
             mMediaStoreCompat.setCaptureStrategy(mSpec.captureStrategy);
+            mMediaStoreCompat.onCreate(savedInstanceState);
         }
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
@@ -157,6 +158,7 @@ public class MatisseActivity extends AppCompatActivity implements
         super.onSaveInstanceState(outState);
         mSelectedCollection.onSaveInstanceState(outState);
         mAlbumCollection.onSaveInstanceState(outState);
+        mMediaStoreCompat.onSaveInstanceState(outState);
         outState.putBoolean("checkState", mOriginalEnable);
     }
 


### PR DESCRIPTION
1. fix sumsung take photo nullpointer exception crash bug:configuration changed cause MediaStoreCompat uri and path be cleaned,use saveInstanceState strategy to fix it.

2. fix checkstyle fail : Caused by: java.io.FileNotFoundException: http://www.puppycrawl.com/dtds/configuration_1_3.dtd

   `.gradlew checkstyle` Fail

   ```
   Execution failed for task ':matisse:checkstyle'.
   Unable to create Root Module: configLocation 
   {~/Documents/AndroidDev/MatisseFork/Matisse/checkstyle.xml}, classpath {null}.```
