### PR TITLE
return ALBUM_ID_ALL when album id is null

### DIFF
--- a/matisse/src/main/java/com/zhihu/matisse/internal/entity/Album.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/entity/Album.java
@@ -87,6 +87,10 @@ public class Album implements Parcelable {
     }
 
     public String getId() {
+        if (mId == null) {
+            return ALBUM_ID_ALL;
+        }
+
         return mId;
     }
 


### PR DESCRIPTION
Album id may be null on some machine, this commit will return ALBUM_ID_ALL when album id is null