### PR TITLE
Enable single checked mode

### DIFF
--- a/matisse/src/main/java/com/zhihu/matisse/SelectionCreator.java
+++ b/matisse/src/main/java/com/zhihu/matisse/SelectionCreator.java
@@ -213,6 +213,17 @@ public final class SelectionCreator {
         return this;
     }
 
+    /**
+     * Enable single checked mode
+     *
+     * @param singleChecked Whether to enable single checked or not
+     * @return {@link SelectionCreator} for fluent API.
+     */
+    public SelectionCreator singleChecked(boolean singleChecked) {
+        mSelectionSpec.singleChecked = singleChecked;
+        return this;
+    }
+
 
     /**
      * Determines Whether to hide top and bottom toolbar in PreView mode ,when user tap the picture

--- a/matisse/src/main/java/com/zhihu/matisse/internal/entity/SelectionSpec.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/entity/SelectionSpec.java
@@ -57,6 +57,7 @@ public final class SelectionSpec {
     public int originalMaxSize;
     public OnCheckedListener onCheckedListener;
     public boolean showPreview;
+    public  boolean singleChecked;
 
     private SelectionSpec() {
     }
@@ -93,6 +94,7 @@ public final class SelectionSpec {
         autoHideToobar = false;
         originalMaxSize = Integer.MAX_VALUE;
         showPreview = true;
+        singleChecked = false;
     }
 
     public boolean singleSelectionModeEnabled() {

--- a/matisse/src/main/java/com/zhihu/matisse/internal/model/SelectedItemCollection.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/model/SelectedItemCollection.java
@@ -253,4 +253,8 @@ public class SelectedItemCollection {
         int index = new ArrayList<>(mItems).indexOf(item);
         return index == -1 ? CheckView.UNCHECKED : index + 1;
     }
+
+    public void clear() {
+        mItems.clear();
+    }
 }

--- a/matisse/src/main/java/com/zhihu/matisse/internal/ui/BasePreviewActivity.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/ui/BasePreviewActivity.java
@@ -126,6 +126,10 @@ public abstract class BasePreviewActivity extends AppCompatActivity implements V
                         mCheckView.setChecked(false);
                     }
                 } else {
+                    if (mSpec.singleChecked) {
+                        mSelectedCollection.clear();
+                    }
+
                     if (assertAddSelection(item)) {
                         mSelectedCollection.add(item);
                         if (mSpec.countable) {

--- a/matisse/src/main/java/com/zhihu/matisse/internal/ui/adapter/AlbumMediaAdapter.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/ui/adapter/AlbumMediaAdapter.java
@@ -177,6 +177,10 @@ public class AlbumMediaAdapter extends
         if (mSelectionSpec.countable) {
             int checkedNum = mSelectedCollection.checkedNumOf(item);
             if (checkedNum == CheckView.UNCHECKED) {
+                if (mSelectionSpec.singleChecked) {
+                    mSelectedCollection.clear();
+                }
+
                 if (assertAddSelection(holder.itemView.getContext(), item)) {
                     mSelectedCollection.add(item);
                     notifyCheckStateChanged();
@@ -190,6 +194,10 @@ public class AlbumMediaAdapter extends
                 mSelectedCollection.remove(item);
                 notifyCheckStateChanged();
             } else {
+                if (mSelectionSpec.singleChecked) {
+                    mSelectedCollection.clear();
+                }
+
                 if (assertAddSelection(holder.itemView.getContext(), item)) {
                     mSelectedCollection.add(item);
                     notifyCheckStateChanged();


### PR DESCRIPTION
Follow #55, but we can support single selection by uncheck all other items instead of show error toast when the count over 1 (there is only one checked item at a time)
Use still can preview the photo before applying. 