### PR TITLE
 Enable to choose sort order

### DIFF
--- a/matisse/src/main/java/com/zhihu/matisse/SelectionCreator.java
+++ b/matisse/src/main/java/com/zhihu/matisse/SelectionCreator.java
@@ -19,6 +19,8 @@ package com.zhihu.matisse;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Build;
+import android.provider.MediaStore;
+
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -314,6 +316,28 @@ public final class SelectionCreator {
      */
     public SelectionCreator imageEngine(ImageEngine imageEngine) {
         mSelectionSpec.imageEngine = imageEngine;
+        return this;
+    }
+
+    /***
+     * Set a Album sort order
+     * taken : Sort by date taken
+     * added : Sort by date added
+     * size : Sort by file size
+     * default value : Sort by album default order
+     * @param sortBy
+     * @return
+     */
+    public SelectionCreator albumOrder(String sortBy){
+        if (sortBy.equals("taken")){
+            mSelectionSpec.orderCondition = MediaStore.Images.Media.DATE_TAKEN + " DESC";
+        }else if (sortBy.equals("added")){
+            mSelectionSpec.orderCondition = MediaStore.Images.Media.DATE_ADDED + " DESC";
+        }else if (sortBy.equals("size")){
+            mSelectionSpec.orderCondition = MediaStore.Images.Media.SIZE + " DESC";
+        }else{
+            mSelectionSpec.orderCondition = MediaStore.Images.Media.DEFAULT_SORT_ORDER + " DESC";
+        }
         return this;
     }
 

--- a/matisse/src/main/java/com/zhihu/matisse/SelectionCreator.java
+++ b/matisse/src/main/java/com/zhihu/matisse/SelectionCreator.java
@@ -19,7 +19,6 @@ package com.zhihu.matisse;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Build;
-import android.provider.MediaStore;
 
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
@@ -329,15 +328,7 @@ public final class SelectionCreator {
      * @return
      */
     public SelectionCreator albumOrder(String sortBy){
-        if (sortBy.equals("taken")){
-            mSelectionSpec.orderCondition = MediaStore.Images.Media.DATE_TAKEN + " DESC";
-        }else if (sortBy.equals("added")){
-            mSelectionSpec.orderCondition = MediaStore.Images.Media.DATE_ADDED + " DESC";
-        }else if (sortBy.equals("size")){
-            mSelectionSpec.orderCondition = MediaStore.Images.Media.SIZE + " DESC";
-        }else{
-            mSelectionSpec.orderCondition = MediaStore.Images.Media.DEFAULT_SORT_ORDER + " DESC";
-        }
+        mSelectionSpec.setOrderCondition(sortBy);
         return this;
     }
 

--- a/matisse/src/main/java/com/zhihu/matisse/SelectionCreator.java
+++ b/matisse/src/main/java/com/zhihu/matisse/SelectionCreator.java
@@ -164,7 +164,7 @@ public final class SelectionCreator {
      *
      * @param maxImageSelectable Maximum selectable count for image.
      * @param maxVideoSelectable Maximum selectable count for video.
-     * @return  {@link SelectionCreator} for fluent API.
+     * @return {@link SelectionCreator} for fluent API.
      */
     public SelectionCreator maxSelectablePerMediaType(int maxImageSelectable, int maxVideoSelectable) {
         if (maxImageSelectable < 1 || maxVideoSelectable < 1)
@@ -217,6 +217,7 @@ public final class SelectionCreator {
 
     /**
      * Determines Whether to hide top and bottom toolbar in PreView mode ,when user tap the picture
+     *
      * @param enable
      * @return {@link SelectionCreator} for fluent API.
      */
@@ -327,7 +328,7 @@ public final class SelectionCreator {
      * @param sortBy
      * @return
      */
-    public SelectionCreator albumOrder(String sortBy){
+    public SelectionCreator albumOrder(String sortBy) {
         mSelectionSpec.setOrderCondition(sortBy);
         return this;
     }

--- a/matisse/src/main/java/com/zhihu/matisse/internal/entity/SelectionSpec.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/entity/SelectionSpec.java
@@ -31,11 +31,14 @@ import com.zhihu.matisse.listener.OnSelectedListener;
 import java.util.List;
 import java.util.Set;
 
+import static com.zhihu.matisse.internal.loader.AlbumMediaLoader.ORDER_BY_DEFAULT;
+
 public final class SelectionSpec {
 
     public Set<MimeType> mimeTypeSet;
     public boolean mediaTypeExclusive;
     public boolean showSingleMediaType;
+    public String orderCondition;
     @StyleRes
     public int themeId;
     public int orientation;
@@ -93,6 +96,7 @@ public final class SelectionSpec {
         autoHideToobar = false;
         originalMaxSize = Integer.MAX_VALUE;
         showPreview = true;
+        orderCondition = ORDER_BY_DEFAULT;
     }
 
     public boolean singleSelectionModeEnabled() {

--- a/matisse/src/main/java/com/zhihu/matisse/internal/entity/SelectionSpec.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/entity/SelectionSpec.java
@@ -17,7 +17,6 @@
 package com.zhihu.matisse.internal.entity;
 
 import android.content.pm.ActivityInfo;
-import android.provider.MediaStore;
 
 import androidx.annotation.StyleRes;
 
@@ -127,8 +126,8 @@ public final class SelectionSpec {
         private static final SelectionSpec INSTANCE = new SelectionSpec();
     }
 
-    public void setOrderCondition(String condition){
-        switch (condition){
+    public void setOrderCondition(String condition) {
+        switch (condition) {
             case "default":
                 this.orderCondition = ORDER_BY_DEFAULT;
             case "taken":

--- a/matisse/src/main/java/com/zhihu/matisse/internal/entity/SelectionSpec.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/entity/SelectionSpec.java
@@ -32,7 +32,10 @@ import com.zhihu.matisse.listener.OnSelectedListener;
 import java.util.List;
 import java.util.Set;
 
+import static com.zhihu.matisse.internal.loader.AlbumMediaLoader.ORDER_BY_DATE_TAKEN;
 import static com.zhihu.matisse.internal.loader.AlbumMediaLoader.ORDER_BY_DEFAULT;
+import static com.zhihu.matisse.internal.loader.AlbumMediaLoader.ORDER_BY_MEDIA_ADDED;
+import static com.zhihu.matisse.internal.loader.AlbumMediaLoader.ORDER_BY_SIZE;
 
 public final class SelectionSpec {
 
@@ -125,14 +128,17 @@ public final class SelectionSpec {
     }
 
     public void setOrderCondition(String condition){
-        if (condition.equals("taken")){
-            this.orderCondition = MediaStore.Images.Media.DATE_TAKEN + " DESC";
-        }else if (condition.equals("added")){
-            this.orderCondition = MediaStore.Images.Media.DATE_ADDED + " DESC";
-        }else if (condition.equals("size")){
-            this.orderCondition = MediaStore.Images.Media.SIZE + " DESC";
-        }else{
-            this.orderCondition = MediaStore.Images.Media.DEFAULT_SORT_ORDER + " DESC";
+        switch (condition){
+            case "default":
+                this.orderCondition = ORDER_BY_DEFAULT;
+            case "taken":
+                this.orderCondition = ORDER_BY_DATE_TAKEN;
+            case "added":
+                this.orderCondition = ORDER_BY_MEDIA_ADDED;
+            case "size":
+                this.orderCondition = ORDER_BY_SIZE;
+            default:
+                this.orderCondition = ORDER_BY_DEFAULT;
         }
     }
 }

--- a/matisse/src/main/java/com/zhihu/matisse/internal/entity/SelectionSpec.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/entity/SelectionSpec.java
@@ -17,6 +17,7 @@
 package com.zhihu.matisse.internal.entity;
 
 import android.content.pm.ActivityInfo;
+import android.provider.MediaStore;
 
 import androidx.annotation.StyleRes;
 
@@ -121,5 +122,17 @@ public final class SelectionSpec {
 
     private static final class InstanceHolder {
         private static final SelectionSpec INSTANCE = new SelectionSpec();
+    }
+
+    public void setOrderCondition(String condition){
+        if (condition.equals("taken")){
+            this.orderCondition = MediaStore.Images.Media.DATE_TAKEN + " DESC";
+        }else if (condition.equals("added")){
+            this.orderCondition = MediaStore.Images.Media.DATE_ADDED + " DESC";
+        }else if (condition.equals("size")){
+            this.orderCondition = MediaStore.Images.Media.SIZE + " DESC";
+        }else{
+            this.orderCondition = MediaStore.Images.Media.DEFAULT_SORT_ORDER + " DESC";
+        }
     }
 }

--- a/matisse/src/main/java/com/zhihu/matisse/internal/loader/AlbumLoader.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/loader/AlbumLoader.java
@@ -169,7 +169,6 @@ public class AlbumLoader extends CursorLoader {
                 order = ORDER_BY_SIZE;
             default:
                 order = ORDER_BY_DEFAULT;
-
         }
         return new AlbumLoader(context, selection, selectionArgs, order);
     }

--- a/matisse/src/main/java/com/zhihu/matisse/internal/loader/AlbumLoader.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/loader/AlbumLoader.java
@@ -36,6 +36,11 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static com.zhihu.matisse.internal.loader.AlbumMediaLoader.ORDER_BY_DATE_TAKEN;
+import static com.zhihu.matisse.internal.loader.AlbumMediaLoader.ORDER_BY_DEFAULT;
+import static com.zhihu.matisse.internal.loader.AlbumMediaLoader.ORDER_BY_MEDIA_ADDED;
+import static com.zhihu.matisse.internal.loader.AlbumMediaLoader.ORDER_BY_SIZE;
+
 /**
  * Load all albums (grouped by bucket_id) into a single cursor.
  */
@@ -118,20 +123,21 @@ public class AlbumLoader extends CursorLoader {
 
     private static final String BUCKET_ORDER_BY = "datetaken DESC";
 
-    private AlbumLoader(Context context, String selection, String[] selectionArgs) {
+    private AlbumLoader(Context context, String selection, String[] selectionArgs, String orderBy) {
         super(
                 context,
                 QUERY_URI,
                 beforeAndroidTen() ? PROJECTION : PROJECTION_29,
                 selection,
                 selectionArgs,
-                BUCKET_ORDER_BY
+                orderBy
         );
     }
 
     public static CursorLoader newInstance(Context context) {
         String selection;
         String[] selectionArgs;
+        String order;
         if (SelectionSpec.getInstance().onlyShowGif()) {
             selection = beforeAndroidTen()
                     ? SELECTION_FOR_SINGLE_MEDIA_GIF_TYPE : SELECTION_FOR_SINGLE_MEDIA_GIF_TYPE_29;
@@ -151,7 +157,25 @@ public class AlbumLoader extends CursorLoader {
             selection = beforeAndroidTen() ? SELECTION : SELECTION_29;
             selectionArgs = SELECTION_ARGS;
         }
-        return new AlbumLoader(context, selection, selectionArgs);
+
+        switch (SelectionSpec.getInstance().orderCondition) {
+            case ORDER_BY_DEFAULT:{
+                order = ORDER_BY_DEFAULT;
+            }
+            case ORDER_BY_DATE_TAKEN:{
+                order = ORDER_BY_DATE_TAKEN;
+            }
+            case ORDER_BY_MEDIA_ADDED:{
+                order = ORDER_BY_MEDIA_ADDED;
+            }
+            case ORDER_BY_SIZE:{
+                order = ORDER_BY_SIZE;
+            }
+            default:{
+                order = ORDER_BY_DEFAULT;
+            }
+        }
+        return new AlbumLoader(context, selection, selectionArgs, order);
     }
 
     @Override

--- a/matisse/src/main/java/com/zhihu/matisse/internal/loader/AlbumLoader.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/loader/AlbumLoader.java
@@ -159,21 +159,17 @@ public class AlbumLoader extends CursorLoader {
         }
 
         switch (SelectionSpec.getInstance().orderCondition) {
-            case ORDER_BY_DEFAULT:{
+            case "default":
                 order = ORDER_BY_DEFAULT;
-            }
-            case ORDER_BY_DATE_TAKEN:{
+            case "taken":
                 order = ORDER_BY_DATE_TAKEN;
-            }
-            case ORDER_BY_MEDIA_ADDED:{
+            case "added":
                 order = ORDER_BY_MEDIA_ADDED;
-            }
-            case ORDER_BY_SIZE:{
+            case "size":
                 order = ORDER_BY_SIZE;
-            }
-            default:{
+            default:
                 order = ORDER_BY_DEFAULT;
-            }
+
         }
         return new AlbumLoader(context, selection, selectionArgs, order);
     }

--- a/matisse/src/main/java/com/zhihu/matisse/internal/loader/AlbumMediaLoader.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/loader/AlbumMediaLoader.java
@@ -120,15 +120,18 @@ public class AlbumMediaLoader extends CursorLoader {
     }
     // ===============================================================
 
-    private static final String ORDER_BY = MediaStore.Images.Media.DATE_TAKEN + " DESC";
+    public static final String ORDER_BY_DEFAULT = MediaStore.Images.Media.DEFAULT_SORT_ORDER + " DESC";
+    public static final String ORDER_BY_DATE_TAKEN = MediaStore.Images.Media.DATE_TAKEN + " DESC";
+    public static final String ORDER_BY_MEDIA_ADDED = MediaStore.Images.Media.DATE_ADDED + " DESC";
+    public static final String ORDER_BY_SIZE = MediaStore.Images.Media.SIZE + " DESC";
     private final boolean mEnableCapture;
 
-    private AlbumMediaLoader(Context context, String selection, String[] selectionArgs, boolean capture) {
-        super(context, QUERY_URI, PROJECTION, selection, selectionArgs, ORDER_BY);
+    private AlbumMediaLoader(Context context, String selection, String[] selectionArgs, boolean capture, String orderCondition) {
+        super(context, QUERY_URI, PROJECTION, selection, selectionArgs, orderCondition);
         mEnableCapture = capture;
     }
 
-    public static CursorLoader newInstance(Context context, Album album, boolean capture) {
+    public static CursorLoader newInstance(Context context, Album album, boolean capture, String orderCondition) {
         String selection;
         String[] selectionArgs;
         boolean enableCapture;
@@ -176,7 +179,7 @@ public class AlbumMediaLoader extends CursorLoader {
             }
             enableCapture = false;
         }
-        return new AlbumMediaLoader(context, selection, selectionArgs, enableCapture);
+        return new AlbumMediaLoader(context, selection, selectionArgs, enableCapture, orderCondition);
     }
 
     @Override

--- a/matisse/src/main/java/com/zhihu/matisse/internal/model/AlbumMediaCollection.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/model/AlbumMediaCollection.java
@@ -30,10 +30,13 @@ import com.zhihu.matisse.internal.loader.AlbumMediaLoader;
 
 import java.lang.ref.WeakReference;
 
+import static com.zhihu.matisse.internal.loader.AlbumMediaLoader.ORDER_BY_DEFAULT;
+
 public class AlbumMediaCollection implements LoaderManager.LoaderCallbacks<Cursor> {
     private static final int LOADER_ID = 2;
     private static final String ARGS_ALBUM = "args_album";
     private static final String ARGS_ENABLE_CAPTURE = "args_enable_capture";
+    private static final String ARGS_SORT_ORDER = "args_album_sort_order";
     private WeakReference<Context> mContext;
     private LoaderManager mLoaderManager;
     private AlbumMediaCallbacks mCallbacks;
@@ -51,7 +54,7 @@ public class AlbumMediaCollection implements LoaderManager.LoaderCallbacks<Curso
         }
 
         return AlbumMediaLoader.newInstance(context, album,
-                album.isAll() && args.getBoolean(ARGS_ENABLE_CAPTURE, false));
+                album.isAll() && args.getBoolean(ARGS_ENABLE_CAPTURE, false), args.getString(ARGS_SORT_ORDER));
     }
 
     @Override
@@ -88,13 +91,14 @@ public class AlbumMediaCollection implements LoaderManager.LoaderCallbacks<Curso
     }
 
     public void load(@Nullable Album target) {
-        load(target, false);
+        load(target, false, ORDER_BY_DEFAULT);
     }
 
-    public void load(@Nullable Album target, boolean enableCapture) {
+    public void load(@Nullable Album target, boolean enableCapture, String order) {
         Bundle args = new Bundle();
         args.putParcelable(ARGS_ALBUM, target);
         args.putBoolean(ARGS_ENABLE_CAPTURE, enableCapture);
+        args.putString(ARGS_SORT_ORDER, order);
         mLoaderManager.initLoader(LOADER_ID, args, this);
     }
 

--- a/matisse/src/main/java/com/zhihu/matisse/internal/ui/MediaSelectionFragment.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/ui/MediaSelectionFragment.java
@@ -110,7 +110,7 @@ public class MediaSelectionFragment extends Fragment implements
         mRecyclerView.addItemDecoration(new MediaGridInset(spanCount, spacing, false));
         mRecyclerView.setAdapter(mAdapter);
         mAlbumMediaCollection.onCreate(getActivity(), this);
-        mAlbumMediaCollection.load(album, selectionSpec.capture);
+        mAlbumMediaCollection.load(album, selectionSpec.capture, selectionSpec.orderCondition);
     }
 
     @Override

--- a/sample/src/main/java/com/zhihu/matisse/sample/SampleActivity.java
+++ b/sample/src/main/java/com/zhihu/matisse/sample/SampleActivity.java
@@ -21,6 +21,7 @@ import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.net.Uri;
 import android.os.Bundle;
+import android.provider.MediaStore;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -104,6 +105,7 @@ public class SampleActivity extends AppCompatActivity implements View.OnClickLis
                         .setOnCheckedListener(isChecked -> {
                             Log.e("isChecked", "onCheck: isChecked=" + isChecked);
                         })
+                        .albumOrder("added")
                         .forResult(REQUEST_CODE_CHOOSE);
                 break;
             case R.id.dracula:

--- a/sample/src/main/java/com/zhihu/matisse/sample/SampleActivity.java
+++ b/sample/src/main/java/com/zhihu/matisse/sample/SampleActivity.java
@@ -21,7 +21,6 @@ import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.net.Uri;
 import android.os.Bundle;
-import android.provider.MediaStore;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;


### PR DESCRIPTION
we can support multiple options to show album sorting orders and able to fix downloaded file order seems random.
Former version only show album order by date taken, so that user can be confused by the difference of native gallery order.

[Usage]

.albumOrder()

"taken" : order by date taken
"added" : order by date added
"size" : order by file size
default : order by default album order