### PR TITLE
Fix issues#812: https://github.com/zhihu/Matisse/issues/812

### DIFF
--- a/matisse/build.gradle
+++ b/matisse/build.gradle
@@ -37,7 +37,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation "androidx.appcompat:appcompat:1.1.0"
+    implementation "androidx.appcompat:appcompat:1.3.1"
     implementation "androidx.annotation:annotation:1.1.0"
     implementation "androidx.recyclerview:recyclerview:1.0.0"
     implementation 'it.sephiroth.android.library.imagezoom:library:1.0.4'

--- a/matisse/src/main/java/com/zhihu/matisse/internal/model/AlbumMediaCollection.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/model/AlbumMediaCollection.java
@@ -21,6 +21,7 @@ import android.database.Cursor;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;
@@ -76,7 +77,13 @@ public class AlbumMediaCollection implements LoaderManager.LoaderCallbacks<Curso
 
     public void onCreate(@NonNull FragmentActivity context, @NonNull AlbumMediaCallbacks callbacks) {
         mContext = new WeakReference<Context>(context);
-        mLoaderManager = context.getSupportLoaderManager();
+        mLoaderManager = LoaderManager.getInstance(context);
+        mCallbacks = callbacks;
+    }
+
+    public void onCreate(@NonNull Fragment fragment, @NonNull AlbumMediaCallbacks callbacks) {
+        mContext = new WeakReference<Context>(fragment.getContext());
+        mLoaderManager = LoaderManager.getInstance(fragment);
         mCallbacks = callbacks;
     }
 

--- a/matisse/src/main/java/com/zhihu/matisse/internal/ui/MediaSelectionFragment.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/ui/MediaSelectionFragment.java
@@ -109,7 +109,7 @@ public class MediaSelectionFragment extends Fragment implements
         int spacing = getResources().getDimensionPixelSize(R.dimen.media_grid_spacing);
         mRecyclerView.addItemDecoration(new MediaGridInset(spanCount, spacing, false));
         mRecyclerView.setAdapter(mAdapter);
-        mAlbumMediaCollection.onCreate(getActivity(), this);
+        mAlbumMediaCollection.onCreate(this, this);
         mAlbumMediaCollection.load(album, selectionSpec.capture);
     }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 //    implementation 'com.zhihu.android:matisse:0.5.2'
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation "androidx.appcompat:appcompat:1.1.0"
+    implementation "androidx.appcompat:appcompat:1.3.1"
     implementation "androidx.recyclerview:recyclerview:1.0.0"
     implementation 'com.tbruyelle.rxpermissions2:rxpermissions:0.9.5@aar'
     implementation 'io.reactivex.rxjava2:rxjava:2.2.12'


### PR DESCRIPTION
Fixed the issue 812. Use the fragment instead of it's activity to as livedata owner. Matisse is good, but we need to support later fragment versions intead of 1.0.0.