### PR TITLE
Upgrade appCompat version for using  ActivityResultLauncher

### DIFF
--- a/matisse/build.gradle
+++ b/matisse/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'checkstyle'
 
 android {
     compileSdkVersion 29
-    buildToolsVersion '29.0.2'
+    buildToolsVersion '29.0.3'
 
     defaultConfig {
         minSdkVersion 14
@@ -37,9 +37,9 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation "androidx.appcompat:appcompat:1.1.0"
-    implementation "androidx.annotation:annotation:1.1.0"
-    implementation "androidx.recyclerview:recyclerview:1.0.0"
+    implementation "androidx.appcompat:appcompat:1.3.0"
+    implementation "androidx.annotation:annotation:1.4.0"
+    implementation "androidx.recyclerview:recyclerview:1.2.1"
     implementation 'it.sephiroth.android.library.imagezoom:library:1.0.4'
 
     compileOnly 'com.github.bumptech.glide:glide:4.9.0'

--- a/matisse/src/main/java/com/zhihu/matisse/SelectionCreator.java
+++ b/matisse/src/main/java/com/zhihu/matisse/SelectionCreator.java
@@ -19,6 +19,8 @@ package com.zhihu.matisse;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Build;
+
+import androidx.activity.result.ActivityResultLauncher;
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -348,7 +350,7 @@ public final class SelectionCreator {
      *
      * @param requestCode Identity of the request Activity or Fragment.
      */
-    public void forResult(int requestCode) {
+    public void forResult(ActivityResultLauncher<Intent> activityResultLauncher) {
         Activity activity = mMatisse.getActivity();
         if (activity == null) {
             return;
@@ -357,11 +359,7 @@ public final class SelectionCreator {
         Intent intent = new Intent(activity, MatisseActivity.class);
 
         Fragment fragment = mMatisse.getFragment();
-        if (fragment != null) {
-            fragment.startActivityForResult(intent, requestCode);
-        } else {
-            activity.startActivityForResult(intent, requestCode);
-        }
+        activityResultLauncher.launch(intent);
     }
 
     public SelectionCreator showPreview(boolean showPreview) {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 //    implementation 'com.zhihu.android:matisse:0.5.2'
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation "androidx.appcompat:appcompat:1.1.0"
+    implementation "androidx.appcompat:appcompat:1.3.0"
     implementation "androidx.recyclerview:recyclerview:1.0.0"
     implementation 'com.tbruyelle.rxpermissions2:rxpermissions:0.9.5@aar'
     implementation 'io.reactivex.rxjava2:rxjava:2.2.12'

--- a/sample/src/main/java/com/zhihu/matisse/sample/SampleActivity.java
+++ b/sample/src/main/java/com/zhihu/matisse/sample/SampleActivity.java
@@ -17,6 +17,7 @@ package com.zhihu.matisse.sample;
 
 import android.Manifest;
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.net.Uri;
@@ -28,6 +29,10 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.activity.result.ActivityResult;
+import androidx.activity.result.ActivityResultCallback;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -47,6 +52,18 @@ public class SampleActivity extends AppCompatActivity implements View.OnClickLis
     private static final int REQUEST_CODE_CHOOSE = 23;
 
     private UriAdapter mAdapter;
+
+    ActivityResultLauncher<Intent> activityResultLauncher = registerForActivityResult(
+            new ActivityResultContracts.StartActivityForResult(),
+            new ActivityResultCallback<ActivityResult>() {
+                @Override
+                public void onActivityResult(ActivityResult result) {
+                    if (result.getResultCode() == Activity.RESULT_OK) {
+                        mAdapter.setData(Matisse.obtainResult(result.getData()), Matisse.obtainPathResult(result.getData()));
+                        Log.e("OnActivityResult ", String.valueOf(Matisse.obtainOriginalState(result.getData())));
+                    }
+                }
+            });
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -104,7 +121,7 @@ public class SampleActivity extends AppCompatActivity implements View.OnClickLis
                         .setOnCheckedListener(isChecked -> {
                             Log.e("isChecked", "onCheck: isChecked=" + isChecked);
                         })
-                        .forResult(REQUEST_CODE_CHOOSE);
+                        .forResult(activityResultLauncher);
                 break;
             case R.id.dracula:
                 Matisse.from(SampleActivity.this)
@@ -116,7 +133,7 @@ public class SampleActivity extends AppCompatActivity implements View.OnClickLis
                         .originalEnable(true)
                         .maxOriginalSize(10)
                         .imageEngine(new PicassoEngine())
-                        .forResult(REQUEST_CODE_CHOOSE);
+                        .forResult(activityResultLauncher);
                 break;
             case R.id.only_gif:
                 Matisse.from(SampleActivity.this)
@@ -133,21 +150,12 @@ public class SampleActivity extends AppCompatActivity implements View.OnClickLis
                         .originalEnable(true)
                         .maxOriginalSize(10)
                         .autoHideToolbarOnSingleTap(true)
-                        .forResult(REQUEST_CODE_CHOOSE);
+                        .forResult(activityResultLauncher);
                 break;
             default:
                 break;
         }
         mAdapter.setData(null, null);
-    }
-
-    @Override
-    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
-        if (requestCode == REQUEST_CODE_CHOOSE && resultCode == RESULT_OK) {
-            mAdapter.setData(Matisse.obtainResult(data), Matisse.obtainPathResult(data));
-            Log.e("OnActivityResult ", String.valueOf(Matisse.obtainOriginalState(data)));
-        }
     }
 
     private static class UriAdapter extends RecyclerView.Adapter<UriAdapter.UriViewHolder> {


### PR DESCRIPTION
Hi
I upgrade appCompat version to 1.3.0 for using  ActivityResultLauncher instead of deprecated onActivityResult().
higher version of appCompat cause unexpected crash.