### PR TITLE
Feature/add feature selected picture

### DIFF
--- a/matisse/src/main/java/com/zhihu/matisse/SelectionCreator.java
+++ b/matisse/src/main/java/com/zhihu/matisse/SelectionCreator.java
@@ -267,8 +267,8 @@ public final class SelectionCreator {
      * set last choose uris to make these pictures be selected by default.
      * id is cursor id. not support crop picture
      */
-    public SelectionCreator setSelectedItems(ArrayList<Uri> list) {
-        mSelectionSpec.selectedPictureUris = list;
+    public SelectionCreator setSelectedItems(ArrayList<String> list) {
+        mSelectionSpec.selectedFilePath = list;
         return this;
     }
 

--- a/matisse/src/main/java/com/zhihu/matisse/SelectionCreator.java
+++ b/matisse/src/main/java/com/zhihu/matisse/SelectionCreator.java
@@ -18,7 +18,9 @@ package com.zhihu.matisse;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Build;
+
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -163,7 +165,7 @@ public final class SelectionCreator {
      *
      * @param maxImageSelectable Maximum selectable count for image.
      * @param maxVideoSelectable Maximum selectable count for video.
-     * @return  {@link SelectionCreator} for fluent API.
+     * @return {@link SelectionCreator} for fluent API.
      */
     public SelectionCreator maxSelectablePerMediaType(int maxImageSelectable, int maxVideoSelectable) {
         if (maxImageSelectable < 1 || maxVideoSelectable < 1)
@@ -216,6 +218,7 @@ public final class SelectionCreator {
 
     /**
      * Determines Whether to hide top and bottom toolbar in PreView mode ,when user tap the picture
+     *
      * @param enable
      * @return {@link SelectionCreator} for fluent API.
      */
@@ -257,6 +260,15 @@ public final class SelectionCreator {
      */
     public SelectionCreator restrictOrientation(@ScreenOrientation int orientation) {
         mSelectionSpec.orientation = orientation;
+        return this;
+    }
+
+    /**
+     * set last choose uris to make these pictures be selected by default.
+     * id is cursor id. not support crop picture
+     */
+    public SelectionCreator setSelectedItems(ArrayList<Uri> list) {
+        mSelectionSpec.selectedPictureUris = list;
         return this;
     }
 

--- a/matisse/src/main/java/com/zhihu/matisse/internal/entity/SelectionSpec.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/entity/SelectionSpec.java
@@ -17,6 +17,7 @@
 package com.zhihu.matisse.internal.entity;
 
 import android.content.pm.ActivityInfo;
+import android.net.Uri;
 
 import androidx.annotation.StyleRes;
 
@@ -28,6 +29,7 @@ import com.zhihu.matisse.filter.Filter;
 import com.zhihu.matisse.listener.OnCheckedListener;
 import com.zhihu.matisse.listener.OnSelectedListener;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -57,6 +59,7 @@ public final class SelectionSpec {
     public int originalMaxSize;
     public OnCheckedListener onCheckedListener;
     public boolean showPreview;
+    public ArrayList<Uri> selectedPictureUris;
 
     private SelectionSpec() {
     }
@@ -93,6 +96,7 @@ public final class SelectionSpec {
         autoHideToobar = false;
         originalMaxSize = Integer.MAX_VALUE;
         showPreview = true;
+        selectedPictureUris = null;
     }
 
     public boolean singleSelectionModeEnabled() {

--- a/matisse/src/main/java/com/zhihu/matisse/internal/entity/SelectionSpec.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/entity/SelectionSpec.java
@@ -59,7 +59,7 @@ public final class SelectionSpec {
     public int originalMaxSize;
     public OnCheckedListener onCheckedListener;
     public boolean showPreview;
-    public ArrayList<Uri> selectedPictureUris;
+    public ArrayList<String> selectedFilePath;
 
     private SelectionSpec() {
     }
@@ -96,7 +96,7 @@ public final class SelectionSpec {
         autoHideToobar = false;
         originalMaxSize = Integer.MAX_VALUE;
         showPreview = true;
-        selectedPictureUris = null;
+        selectedFilePath = null;
     }
 
     public boolean singleSelectionModeEnabled() {

--- a/matisse/src/main/java/com/zhihu/matisse/internal/ui/adapter/AlbumMediaAdapter.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/ui/adapter/AlbumMediaAdapter.java
@@ -20,8 +20,13 @@ import android.content.res.TypedArray;
 import android.database.Cursor;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
+
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
+
+import android.net.Uri;
+import android.provider.MediaStore;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -36,6 +41,9 @@ import com.zhihu.matisse.internal.entity.IncapableCause;
 import com.zhihu.matisse.internal.model.SelectedItemCollection;
 import com.zhihu.matisse.internal.ui.widget.CheckView;
 import com.zhihu.matisse.internal.ui.widget.MediaGrid;
+
+import java.io.File;
+import java.util.Objects;
 
 public class AlbumMediaAdapter extends
         RecyclerViewCursorAdapter<RecyclerView.ViewHolder> implements
@@ -121,11 +129,13 @@ public class AlbumMediaAdapter extends
             ));
             mediaViewHolder.mMediaGrid.bindMedia(item);
             mediaViewHolder.mMediaGrid.setOnMediaGridClickListener(this);
+            setSelectedItems(item);
             setCheckStatus(item, mediaViewHolder.mMediaGrid);
         }
     }
 
     private void setCheckStatus(Item item, MediaGrid mediaGrid) {
+
         if (mSelectionSpec.countable) {
             int checkedNum = mSelectedCollection.checkedNumOf(item);
             if (checkedNum > 0) {
@@ -155,6 +165,24 @@ public class AlbumMediaAdapter extends
                 }
             }
         }
+    }
+
+    /**
+     * 初始化外部传入上次选中的图片
+     */
+    private void setSelectedItems(Item item) {
+        if (mSelectionSpec.selectedPictureUris == null || mSelectionSpec.selectedPictureUris.size() == 0)
+            return;
+
+        for (int index = 0; index < mSelectionSpec.selectedPictureUris.size(); ++index) {
+            Uri uri = mSelectionSpec.selectedPictureUris.get(index);
+            if (uri != null &&
+                    Objects.equals(uri.toString(), item.getContentUri().toString())) {
+                mSelectedCollection.add(item);
+                mSelectionSpec.selectedPictureUris.set(index, null);
+            }
+        }
+
     }
 
     @Override

--- a/matisse/src/main/java/com/zhihu/matisse/ui/MatisseActivity.java
+++ b/matisse/src/main/java/com/zhihu/matisse/ui/MatisseActivity.java
@@ -163,13 +163,13 @@ public class MatisseActivity extends AppCompatActivity implements
 
         SelectionSpec selectionSpec = SelectionSpec.getInstance();
 
-        if (selectionSpec.selectedPictureUris == null || selectionSpec.selectedPictureUris.size() == 0)
+        if (selectionSpec.selectedFilePath == null || selectionSpec.selectedFilePath.size() == 0)
             return;
 
         int selectedCount = 0;
-        for (int index = 0; index < selectionSpec.selectedPictureUris.size(); ++index) {
+        for (int index = 0; index < selectionSpec.selectedFilePath.size(); ++index) {
 
-            if (selectionSpec.selectedPictureUris.get(index) != null) ++selectedCount;
+            if (selectionSpec.selectedFilePath.get(index) != null) ++selectedCount;
         }
 
         if(selectedCount > 0){

--- a/matisse/src/main/java/com/zhihu/matisse/ui/MatisseActivity.java
+++ b/matisse/src/main/java/com/zhihu/matisse/ui/MatisseActivity.java
@@ -26,6 +26,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.appcompat.app.ActionBar;
@@ -59,6 +60,7 @@ import com.zhihu.matisse.internal.utils.PathUtils;
 import com.zhihu.matisse.internal.utils.PhotoMetadataUtils;
 
 import com.zhihu.matisse.internal.utils.SingleMediaScanner;
+
 import java.util.ArrayList;
 
 /**
@@ -153,6 +155,28 @@ public class MatisseActivity extends AppCompatActivity implements
         mAlbumCollection.onCreate(this, this);
         mAlbumCollection.onRestoreInstanceState(savedInstanceState);
         mAlbumCollection.loadAlbums();
+        initDefaultSelectedPictures();
+    }
+
+
+    private void initDefaultSelectedPictures() {
+
+        SelectionSpec selectionSpec = SelectionSpec.getInstance();
+
+        if (selectionSpec.selectedPictureUris == null || selectionSpec.selectedPictureUris.size() == 0)
+            return;
+
+        int selectedCount = 0;
+        for (int index = 0; index < selectionSpec.selectedPictureUris.size(); ++index) {
+
+            if (selectionSpec.selectedPictureUris.get(index) != null) ++selectedCount;
+        }
+
+        if(selectedCount > 0){
+            mButtonPreview.setEnabled(true);
+            mButtonApply.setEnabled(true);
+            mButtonApply.setText(getString(R.string.button_apply, selectedCount));
+        }
     }
 
     @Override
@@ -239,7 +263,8 @@ public class MatisseActivity extends AppCompatActivity implements
                         Intent.FLAG_GRANT_WRITE_URI_PERMISSION | Intent.FLAG_GRANT_READ_URI_PERMISSION);
 
             new SingleMediaScanner(this.getApplicationContext(), path, new SingleMediaScanner.ScanListener() {
-                @Override public void onScanFinish() {
+                @Override
+                public void onScanFinish() {
                     Log.i("SingleMediaScanner", "scan finish!");
                 }
             });

--- a/sample/src/main/java/com/zhihu/matisse/sample/SampleActivity.java
+++ b/sample/src/main/java/com/zhihu/matisse/sample/SampleActivity.java
@@ -143,13 +143,13 @@ public class SampleActivity extends AppCompatActivity implements View.OnClickLis
         mAdapter.setData(null, null);
     }
 
-    private ArrayList<Uri> selectedList = new ArrayList<>();
+    private ArrayList<String> selectedList = new ArrayList<>();
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == REQUEST_CODE_CHOOSE && resultCode == RESULT_OK) {
             selectedList.clear();
-            selectedList.addAll(Matisse.obtainResult(data));
+            selectedList.addAll(Matisse.obtainPathResult(data));
             mAdapter.setData(Matisse.obtainResult(data), Matisse.obtainPathResult(data));
             Log.e("OnActivityResult ", String.valueOf(Matisse.obtainOriginalState(data)));
         }

--- a/sample/src/main/java/com/zhihu/matisse/sample/SampleActivity.java
+++ b/sample/src/main/java/com/zhihu/matisse/sample/SampleActivity.java
@@ -40,6 +40,7 @@ import com.zhihu.matisse.engine.impl.PicassoEngine;
 import com.zhihu.matisse.filter.Filter;
 import com.zhihu.matisse.internal.entity.CaptureStrategy;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class SampleActivity extends AppCompatActivity implements View.OnClickListener {
@@ -91,6 +92,7 @@ public class SampleActivity extends AppCompatActivity implements View.OnClickLis
                         .addFilter(new GifSizeFilter(320, 320, 5 * Filter.K * Filter.K))
                         .gridExpectedSize(
                                 getResources().getDimensionPixelSize(R.dimen.grid_expected_size))
+                        .setSelectedItems(selectedList)
                         .restrictOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT)
                         .thumbnailScale(0.85f)
                         .imageEngine(new GlideEngine())
@@ -141,10 +143,13 @@ public class SampleActivity extends AppCompatActivity implements View.OnClickLis
         mAdapter.setData(null, null);
     }
 
+    private ArrayList<Uri> selectedList = new ArrayList<>();
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == REQUEST_CODE_CHOOSE && resultCode == RESULT_OK) {
+            selectedList.clear();
+            selectedList.addAll(Matisse.obtainResult(data));
             mAdapter.setData(Matisse.obtainResult(data), Matisse.obtainPathResult(data));
             Log.e("OnActivityResult ", String.valueOf(Matisse.obtainOriginalState(data)));
         }


### PR DESCRIPTION
A lot of users asked a feature that the MatisseActivity page can select those pictures users selected before by default.

So that I add a new api for it:
`SelectionCreator.setSelectedItems(ArrayList<String> list)`
This worked well.

Use case:

```
   // Define a list to cache those pictures selected by user
   private ArrayList<String> selectedList = new ArrayList<>();

   // Save selected pictures.
    @Override
    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
        super.onActivityResult(requestCode, resultCode, data);
        if (requestCode == REQUEST_CODE_CHOOSE && resultCode == RESULT_OK) {
            selectedList.clear();
            selectedList.addAll(Matisse.obtainPathResult(data));-
        }
    }

   // Open the album
   Matisse.from(SampleActivity.this)
                        .choose(MimeType.ofImage(), false)
                        .countable(true)
                        .setSelectedItems(selectedList) // pass those selected pictures.
                        .forResult(REQUEST_CODE_CHOOSE);
```